### PR TITLE
Add new update access routes functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "0.0.12"
+version = "0.0.13"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -189,6 +189,37 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "update_access_routes"
+      ],
+      "properties": {
+        "update_access_routes": {
+          "type": "object",
+          "required": [
+            "access_routes",
+            "identifier",
+            "owner_address"
+          ],
+          "properties": {
+            "access_routes": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AccessRoute"
+              }
+            },
+            "identifier": {
+              "$ref": "#/definitions/AssetIdentifier"
+            },
+            "owner_address": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -3,6 +3,7 @@ use crate::execute::add_asset_definition::{add_asset_definition, AddAssetDefinit
 use crate::execute::add_asset_verifier::{add_asset_verifier, AddAssetVerifierV1};
 use crate::execute::onboard_asset::{onboard_asset, OnboardAssetV1};
 use crate::execute::toggle_asset_definition::{toggle_asset_definition, ToggleAssetDefinitionV1};
+use crate::execute::update_access_routes::{update_access_routes, UpdateAccessRoutesV1};
 use crate::execute::update_asset_definition::{update_asset_definition, UpdateAssetDefinitionV1};
 use crate::execute::update_asset_verifier::{update_asset_verifier, UpdateAssetVerifierV1};
 use crate::execute::verify_asset::{verify_asset, VerifyAssetV1};
@@ -78,6 +79,11 @@ pub fn execute(deps: DepsMutC, env: Env, info: MessageInfo, msg: ExecuteMsg) -> 
         ExecuteMsg::UpdateAssetVerifier { .. } => {
             update_asset_verifier(deps, info, UpdateAssetVerifierV1::from_execute_msg(msg)?)
         }
+        ExecuteMsg::UpdateAccessRoutes { .. } => update_access_routes(
+            AssetMetaService::new(deps),
+            info,
+            UpdateAccessRoutesV1::from_execute_msg(msg)?,
+        ),
     }
 }
 

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -49,6 +49,11 @@ pub enum ExecuteMsg {
         asset_type: String,
         verifier: VerifierDetail,
     },
+    UpdateAccessRoutes {
+        identifier: AssetIdentifier,
+        owner_address: String,
+        access_routes: Vec<AccessRoute>,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/execute/mod.rs
+++ b/src/execute/mod.rs
@@ -2,6 +2,7 @@ pub mod add_asset_definition;
 pub mod add_asset_verifier;
 pub mod onboard_asset;
 pub mod toggle_asset_definition;
+pub mod update_access_routes;
 pub mod update_asset_definition;
 pub mod update_asset_verifier;
 pub mod verify_asset;

--- a/src/execute/update_access_routes.rs
+++ b/src/execute/update_access_routes.rs
@@ -84,7 +84,6 @@ where
     {
         let mut new_access_definitions = scope_attribute
             .access_definitions
-            .clone()
             .into_iter()
             .filter(|def| def != &target_access_definition)
             .collect::<Vec<AccessDefinition>>();
@@ -94,7 +93,7 @@ where
             .append(&mut access_routes);
         new_access_definitions.push(target_access_definition);
         scope_attribute.access_definitions = new_access_definitions;
-        repository.update_attribute(&scope_attribute);
+        repository.update_attribute(&scope_attribute)?;
     } else {
         // If no access definitions are established for the given owner address, then the request is
         // invalid and should be rejected

--- a/src/execute/update_access_routes.rs
+++ b/src/execute/update_access_routes.rs
@@ -8,6 +8,7 @@ use crate::service::asset_meta_repository::AssetMetaRepository;
 use crate::service::deps_manager::DepsManager;
 use crate::service::message_gathering_service::MessageGatheringService;
 use crate::util::aliases::{AssetResult, EntryPointResponse};
+use crate::util::contract_helpers::check_funds_are_empty;
 use crate::util::event_attributes::{EventAttributes, EventType};
 use crate::util::functions::filter_valid_access_routes;
 use crate::util::traits::ResultExtensions;
@@ -55,9 +56,10 @@ pub fn update_access_routes<'a, T>(
 where
     T: AssetMetaRepository + MessageGatheringService + DepsManager<'a>,
 {
+    check_funds_are_empty(&info)?;
     // If the sender is not the specified owner address and the sender is not the admin, they are
     // not authorized to change access routes
-    if info.sender.to_string() != msg.owner_address
+    if info.sender != msg.owner_address
         && info.sender
             != repository
                 .use_deps(|deps| config_read_v2(deps.storage).load())?
@@ -65,50 +67,481 @@ where
     {
         return ContractError::Unauthorized {
             explanation:
-                "Only the admin or owner of the given access routes can make modifications to them"
+                "only the admin or owner of the given access routes can make modifications to them"
                     .to_string(),
         }
         .to_err();
     }
     let mut access_routes = filter_valid_access_routes(msg.access_routes.clone());
-    if access_routes.is_empty() {
-        return ContractError::generic("No valid access routes were provided").to_err();
+    if msg.access_routes.len() != access_routes.len() {
+        // The filtration function will trim duplicate routes, as well as invalid routes
+        return ContractError::generic("invalid or duplicate access routes were provided").to_err();
     }
     let scope_address = msg.identifier.get_scope_address()?;
     let mut scope_attribute = repository.get_asset(&scope_address)?;
     if let Some(mut target_access_definition) = scope_attribute
         .access_definitions
         .iter()
-        .find(|def| &def.owner_address == &msg.owner_address)
+        .find(|def| def.owner_address == msg.owner_address)
         .map(|def| def.to_owned())
     {
-        let mut new_access_definitions = scope_attribute
+        // Filter the access definition to be changed from the attribute's vector
+        scope_attribute.access_definitions = scope_attribute
             .access_definitions
             .into_iter()
             .filter(|def| def != &target_access_definition)
             .collect::<Vec<AccessDefinition>>();
+        // Remove all existing access routes on the target definition to change
         target_access_definition.access_routes.clear();
+        // Add all access routes from the request into the definition
         target_access_definition
             .access_routes
             .append(&mut access_routes);
-        new_access_definitions.push(target_access_definition);
-        scope_attribute.access_definitions = new_access_definitions;
+        // Append the altered definition to the scope attribute, effectively "replacing" the original record
+        scope_attribute
+            .access_definitions
+            .push(target_access_definition);
         repository.update_attribute(&scope_attribute)?;
     } else {
         // If no access definitions are established for the given owner address, then the request is
         // invalid and should be rejected
         return ContractError::InvalidAddress {
             address: msg.owner_address,
-            explanation: format!("Scope attribute for address [{scope_address}] does not have access definitions for specified owner"),
+            explanation: format!("scope attribute for address [{scope_address}] does not have access definitions for specified owner"),
         }.to_err();
     }
     Response::new()
         .add_attributes(
             EventAttributes::new(EventType::UpdateAccessRoutes)
                 .set_asset_type(&scope_attribute.asset_type)
-                .set_scope_address(&scope_address)
-                .set_new_value(access_routes.len()),
+                .set_scope_address(&scope_address),
         )
         .add_messages(repository.get_messages())
         .to_ok()
+}
+
+#[cfg(test)]
+#[cfg(feature = "enable-test-utils")]
+mod tests {
+    use super::*;
+    use crate::contract::execute;
+    use crate::service::asset_meta_service::AssetMetaService;
+    use crate::testutil::onboard_asset_helpers::{test_onboard_asset, TestOnboardAsset};
+    use crate::testutil::test_constants::{
+        DEFAULT_ADMIN_ADDRESS, DEFAULT_ASSET_TYPE, DEFAULT_CONTRACT_BASE_NAME,
+        DEFAULT_SCOPE_ADDRESS, DEFAULT_SENDER_ADDRESS, DEFAULT_VERIFIER_ADDRESS,
+    };
+    use crate::testutil::test_utilities::{
+        assert_single_item, empty_mock_info, setup_test_suite, single_attribute_for_key, InstArgs,
+    };
+    use crate::testutil::update_access_routes_helpers::{
+        test_update_access_routes, TestUpdateAccessRoutes,
+    };
+    use crate::testutil::verify_asset_helpers::{test_verify_asset, TestVerifyAsset};
+    use crate::util::constants::{ASSET_EVENT_TYPE_KEY, ASSET_SCOPE_ADDRESS_KEY, ASSET_TYPE_KEY};
+    use crate::util::functions::generate_asset_attribute_name;
+    use crate::util::traits::OptionExtensions;
+    use cosmwasm_std::testing::{mock_env, mock_info};
+    use cosmwasm_std::{coin, CosmosMsg};
+    use provwasm_mocks::mock_dependencies;
+    use provwasm_std::{
+        AttributeMsgParams, AttributeValueType, ProvenanceMsg, ProvenanceMsgParams,
+    };
+
+    #[test]
+    fn test_error_for_provided_funds() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        let err = update_access_routes(
+            AssetMetaService::new(deps.as_mut()),
+            mock_info(DEFAULT_ADMIN_ADDRESS, &[coin(111, "coindollars")]),
+            get_valid_update_routes_v1(),
+        )
+        .expect_err("expected a ContractError to be emitted when funds are provided");
+        match err {
+            ContractError::InvalidFunds(message) => {
+                assert_eq!(
+                    "route requires no funds be present", message,
+                    "unexpected InvalidFunds message encountered",
+                );
+            }
+            _ => panic!("unexpected error encountered: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn test_error_for_invalid_sender() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        let err = update_access_routes(
+            AssetMetaService::new(deps.as_mut()),
+            empty_mock_info("wrong-sender"),
+            get_valid_update_routes_v1(),
+        )
+        .expect_err("expected a ContractError to be emitted when an invalid sender is provided");
+        match err {
+            ContractError::Unauthorized { explanation } => {
+                assert_eq!(
+                    "only the admin or owner of the given access routes can make modifications to them",
+                    explanation,
+                    "unexpected Unauthorized error message encountered",
+                );
+            }
+            _ => panic!("unexpected error encountered: {:?}", err),
+        }
+    }
+
+    // Doing an update with NO access routes is completely valid, but providing any invalid routes
+    // gets rejected to ensure that user error does not result in incorrect output
+    #[test]
+    fn test_error_for_no_valid_access_routes() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        let err = update_access_routes(
+            AssetMetaService::new(deps.as_mut()),
+            empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+            UpdateAccessRoutesV1::new(
+                AssetIdentifier::scope_address(DEFAULT_SCOPE_ADDRESS),
+                DEFAULT_SENDER_ADDRESS,
+                vec![AccessRoute::new("", "".to_some())],
+            ),
+        )
+        .expect_err(
+            "expected a ContractError to be emitted when an invalid AccessRoutes are provided",
+        );
+        match err {
+            ContractError::GenericError { msg } => {
+                assert_eq!(
+                    "invalid or duplicate access routes were provided", msg,
+                    "unexpected generic error message countered"
+                );
+            }
+            _ => panic!("unexpected error encountered: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn test_error_for_no_access_definitions_for_owner() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        let err = update_access_routes(
+            AssetMetaService::new(deps.as_mut()),
+            empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+            UpdateAccessRoutesV1::new(
+                AssetIdentifier::scope_address(DEFAULT_SCOPE_ADDRESS),
+                "some random person",
+                vec![AccessRoute::new("fakeroute", "something-idk".to_some())],
+            )
+        ).expect_err(
+            "expected a ContractError to be emitted when the specified owner does not have an access definition on the scope",
+        );
+        match err {
+            ContractError::InvalidAddress {
+                address,
+                explanation,
+            } => {
+                assert_eq!(
+                    "some random person", address,
+                    "expected the input address to be used in the error message",
+                );
+                assert_eq!(
+                    format!("scope attribute for address [{DEFAULT_SCOPE_ADDRESS}] does not have access definitions for specified owner"),
+                    explanation,
+                    "unexpected InvalidAddress explanation encountered",
+                );
+            }
+            _ => panic!("unexpected error encountered: {:?}", err),
+        }
+    }
+
+    #[test]
+    fn test_successful_update_access_routes_by_route_owner() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        let attribute_before_update = AssetMetaService::new(deps.as_mut()).get_asset(DEFAULT_SCOPE_ADDRESS).expect(
+            "expected a scope attribute to be available for the default address after onboarding",
+        );
+        assert!(
+            attribute_before_update
+                .access_definitions
+                .iter()
+                .any(|def| def.owner_address == DEFAULT_SENDER_ADDRESS),
+            "expected an access definition to exist for the sender address",
+        );
+        let access_route_before_update = assert_single_item(
+            &assert_single_item(
+                &attribute_before_update.access_definitions,
+                "an onboard should leave only a single access definition on the scope attribute",
+            )
+            .access_routes,
+            "only a single access route should be added during onboarding",
+        );
+        // Use test_update_access_routes to ensure the AssetScopeAttribute changes get recorded and
+        // are available after execution
+        let response = test_update_access_routes(
+            &mut deps,
+            TestUpdateAccessRoutes {
+                info: empty_mock_info(DEFAULT_SENDER_ADDRESS),
+                update_access_routes: get_valid_update_routes_v1(),
+            },
+        )
+        .expect("expected the update to complete successfully");
+        assert_eq!(
+            2,
+            response.messages.len(),
+            "expected the update to emit the correct number of messages"
+        );
+        let expected_attribute_name =
+            generate_asset_attribute_name(DEFAULT_ASSET_TYPE, DEFAULT_CONTRACT_BASE_NAME);
+        response.messages.iter().for_each(|msg| match &msg.msg {
+            CosmosMsg::Custom(ProvenanceMsg {
+                params:
+                    ProvenanceMsgParams::Attribute(AttributeMsgParams::DeleteAttribute {
+                        address,
+                        name,
+                    }),
+                ..
+            }) => {
+                assert_eq!(
+                    DEFAULT_SCOPE_ADDRESS,
+                    address.to_string(),
+                    "the DeleteAttribute should target the scope's address",
+                );
+                assert_eq!(
+                    &expected_attribute_name, name,
+                    "the DeleteAttribute should target the default attribute name",
+                );
+            }
+            CosmosMsg::Custom(ProvenanceMsg {
+                params:
+                    ProvenanceMsgParams::Attribute(AttributeMsgParams::AddAttribute {
+                        address,
+                        name,
+                        value_type,
+                        ..
+                    }),
+                ..
+            }) => {
+                assert_eq!(
+                    DEFAULT_SCOPE_ADDRESS,
+                    address.to_string(),
+                    "the AddAttribute should target the scope's address",
+                );
+                assert_eq!(
+                    &expected_attribute_name, name,
+                    "the AddAttribute should target the default attribute name",
+                );
+                assert_eq!(
+                    &AttributeValueType::Json,
+                    value_type,
+                    "the AddAttribute should add a Json attribute",
+                );
+            }
+            _ => panic!(
+                "unexpected message emitted during update access routes: {:?}",
+                &msg.msg
+            ),
+        });
+        assert_eq!(
+            3,
+            response.attributes.len(),
+            "expected the correct number of attributes to be emitted"
+        );
+        assert_eq!(
+            EventType::UpdateAccessRoutes.event_name(),
+            single_attribute_for_key(&response, ASSET_EVENT_TYPE_KEY),
+            "expected the correct event type to be emitted",
+        );
+        assert_eq!(
+            DEFAULT_ASSET_TYPE,
+            single_attribute_for_key(&response, ASSET_TYPE_KEY),
+            "expected the correct asset type to be emitted",
+        );
+        assert_eq!(
+            DEFAULT_SCOPE_ADDRESS,
+            single_attribute_for_key(&response, ASSET_SCOPE_ADDRESS_KEY),
+            "expected the correct scope address to be emitted",
+        );
+        let attribute_after_update = AssetMetaService::new(deps.as_mut()).get_asset(DEFAULT_SCOPE_ADDRESS).expect("expected to retrieve the attribute successfully after the access route update is completed");
+        assert_eq!(
+            attribute_before_update.access_definitions.len(),
+            attribute_after_update.access_definitions.len(),
+            "the update process should not cause the number of access definitions to change",
+        );
+        let access_route_after_update = assert_single_item(
+            &assert_single_item(
+                &attribute_after_update.access_definitions,
+                "only a single access definition should exist after the update occurs",
+            )
+            .access_routes,
+            "only a single access route should remain after the update",
+        );
+        assert_ne!(
+            access_route_before_update.route, access_route_after_update.route,
+            "the route should be altered after the update",
+        );
+        let name_after_update = access_route_after_update.name.unwrap();
+        assert_ne!(
+            &access_route_before_update.name.unwrap(),
+            &name_after_update,
+            "the name should be altered after the update",
+        );
+        assert_eq!(
+            "grpcs://fake.route:1234", access_route_after_update.route,
+            "the route should reflect the value provided during the update",
+        );
+        assert_eq!(
+            "fake_name", name_after_update,
+            "the name should reflect the value provided during the update",
+        );
+    }
+
+    #[test]
+    fn test_successful_update_access_routes_by_admin() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        test_update_access_routes(
+            &mut deps,
+            TestUpdateAccessRoutes {
+                info: empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+                update_access_routes: get_valid_update_routes_v1(),
+            },
+        )
+        .expect("expected the update to complete successfully");
+    }
+
+    #[test]
+    fn test_successful_update_to_remove_access_routes() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        test_update_access_routes(
+            &mut deps,
+            TestUpdateAccessRoutes {
+                info: empty_mock_info(DEFAULT_SENDER_ADDRESS),
+                update_access_routes: UpdateAccessRoutesV1::new(
+                    AssetIdentifier::scope_address(DEFAULT_SCOPE_ADDRESS),
+                    DEFAULT_SENDER_ADDRESS,
+                    vec![],
+                ),
+            },
+        )
+        .expect("expected the update to complete successfully");
+        let scope_attribute = AssetMetaService::new(deps.as_mut())
+            .get_asset(DEFAULT_SCOPE_ADDRESS)
+            .expect("expected the scope attribute to be available after an update");
+        let access_definition = assert_single_item(
+            &scope_attribute.access_definitions,
+            "only one access definition should be available after an onboard and update",
+        );
+        assert!(
+            access_definition.access_routes.is_empty(),
+            "expected the access routes to be empty after the update succeeds",
+        );
+    }
+
+    #[test]
+    fn test_successful_update_after_verification_retains_other_access_definitions() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        test_verify_asset(&mut deps, TestVerifyAsset::default())
+            .expect("expected the default asset verification to succeed");
+        let attribute_before_update = AssetMetaService::new(deps.as_mut()).get_asset(DEFAULT_SCOPE_ADDRESS).expect(
+            "expected a scope attribute to be available for the default address after onboarding",
+        );
+        let verifier_definition_before_update = attribute_before_update
+            .access_definitions
+            .iter()
+            .find(|def| def.owner_address == DEFAULT_VERIFIER_ADDRESS)
+            .expect("expected an access definition for the verifier to exist");
+        let sender_definition_before_update = attribute_before_update
+            .access_definitions
+            .iter()
+            .find(|def| def.owner_address == DEFAULT_SENDER_ADDRESS)
+            .expect("expected an access definition for the sender to exist");
+        assert_eq!(
+            2,
+            attribute_before_update.access_definitions.len(),
+            "expected the attribute to contain two different access definitions before the update",
+        );
+        test_update_access_routes(
+            &mut deps,
+            TestUpdateAccessRoutes {
+                info: empty_mock_info(DEFAULT_SENDER_ADDRESS),
+                update_access_routes: get_valid_update_routes_v1(),
+            },
+        )
+        .expect("expected the update to complete successfully");
+        let attribute_after_update = AssetMetaService::new(deps.as_mut())
+            .get_asset(DEFAULT_SCOPE_ADDRESS)
+            .expect("expected the scope attribute to be available after the update");
+        assert_eq!(
+            2,
+            attribute_after_update.access_definitions.len(),
+            "expected the attribute to still contain both access definitions after the update",
+        );
+        let verifier_definition_after_update = attribute_after_update
+            .access_definitions
+            .iter()
+            .find(|def| def.owner_address == DEFAULT_VERIFIER_ADDRESS)
+            .expect("expected an access definition for the verifier to exist after the update");
+        assert_eq!(
+            verifier_definition_before_update, verifier_definition_after_update,
+            "expected the verifier access definition to be completely unmodified after the update",
+        );
+        let sender_definition_after_update = attribute_after_update
+            .access_definitions
+            .iter()
+            .find(|def| def.owner_address == DEFAULT_SENDER_ADDRESS)
+            .expect("expected an access definition for the sender to exist after the update");
+        assert_ne!(
+            sender_definition_before_update, sender_definition_after_update,
+            "expected the sender's access definition to be changed after the update",
+        );
+    }
+
+    #[test]
+    fn test_successful_update_through_execute_function() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test_suite(&mut deps, InstArgs::default());
+        test_onboard_asset(&mut deps, TestOnboardAsset::default())
+            .expect("expected the default asset onboarding to succeed");
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            empty_mock_info(DEFAULT_SENDER_ADDRESS),
+            ExecuteMsg::UpdateAccessRoutes {
+                identifier: AssetIdentifier::scope_address(DEFAULT_SCOPE_ADDRESS),
+                owner_address: DEFAULT_SENDER_ADDRESS.to_string(),
+                access_routes: vec![AccessRoute::new("grpcs://no.u:4433", "some_name".to_some())],
+            },
+        )
+        .expect("expected an update through the execute function to complete successfully");
+    }
+
+    fn get_valid_update_routes_v1() -> UpdateAccessRoutesV1 {
+        UpdateAccessRoutesV1::new(
+            AssetIdentifier::scope_address(DEFAULT_SCOPE_ADDRESS),
+            DEFAULT_SENDER_ADDRESS,
+            vec![AccessRoute::new(
+                "grpcs://fake.route:1234",
+                "fake_name".to_some(),
+            )],
+        )
+    }
 }

--- a/src/execute/update_access_routes.rs
+++ b/src/execute/update_access_routes.rs
@@ -1,0 +1,115 @@
+use crate::core::error::ContractError;
+use crate::core::msg::ExecuteMsg;
+use crate::core::state::config_read_v2;
+use crate::core::types::access_definition::AccessDefinition;
+use crate::core::types::access_route::AccessRoute;
+use crate::core::types::asset_identifier::AssetIdentifier;
+use crate::service::asset_meta_repository::AssetMetaRepository;
+use crate::service::deps_manager::DepsManager;
+use crate::service::message_gathering_service::MessageGatheringService;
+use crate::util::aliases::{AssetResult, EntryPointResponse};
+use crate::util::event_attributes::{EventAttributes, EventType};
+use crate::util::functions::filter_valid_access_routes;
+use crate::util::traits::ResultExtensions;
+use cosmwasm_std::{MessageInfo, Response};
+
+#[derive(Clone, PartialEq)]
+pub struct UpdateAccessRoutesV1 {
+    pub identifier: AssetIdentifier,
+    pub owner_address: String,
+    pub access_routes: Vec<AccessRoute>,
+}
+impl UpdateAccessRoutesV1 {
+    pub fn new<S: Into<String>>(
+        identifier: AssetIdentifier,
+        owner_address: S,
+        access_routes: Vec<AccessRoute>,
+    ) -> Self {
+        Self {
+            identifier,
+            owner_address: owner_address.into(),
+            access_routes,
+        }
+    }
+
+    pub fn from_execute_msg(msg: ExecuteMsg) -> AssetResult<Self> {
+        match msg {
+            ExecuteMsg::UpdateAccessRoutes {
+                identifier,
+                owner_address,
+                access_routes,
+            } => Self::new(identifier, owner_address, access_routes).to_ok(),
+            _ => ContractError::InvalidMessageType {
+                expected_message_type: "ExecuteMsg::UpdateAccessRoutes".to_string(),
+            }
+            .to_err(),
+        }
+    }
+}
+
+pub fn update_access_routes<'a, T>(
+    repository: T,
+    info: MessageInfo,
+    msg: UpdateAccessRoutesV1,
+) -> EntryPointResponse
+where
+    T: AssetMetaRepository + MessageGatheringService + DepsManager<'a>,
+{
+    // If the sender is not the specified owner address and the sender is not the admin, they are
+    // not authorized to change access routes
+    if info.sender.to_string() != msg.owner_address
+        && info.sender
+            != repository
+                .use_deps(|deps| config_read_v2(deps.storage).load())?
+                .admin
+    {
+        return ContractError::Unauthorized {
+            explanation:
+                "Only the admin or owner of the given access routes can make modifications to them"
+                    .to_string(),
+        }
+        .to_err();
+    }
+    let mut access_routes = filter_valid_access_routes(msg.access_routes.clone());
+    if access_routes.is_empty() {
+        return ContractError::generic("No valid access routes were provided").to_err();
+    }
+    let scope_address = msg.identifier.get_scope_address()?;
+    let mut scope_attribute = repository.get_asset(&scope_address)?;
+    if let Some(mut target_access_definition) = scope_attribute
+        .access_definitions
+        .iter()
+        .find(|def| &def.owner_address == &msg.owner_address)
+        .map(|def| def.to_owned())
+    {
+        let mut new_access_definitions = scope_attribute
+            .access_definitions
+            .clone()
+            .into_iter()
+            .filter(|def| def != &target_access_definition)
+            .collect::<Vec<AccessDefinition>>();
+        target_access_definition.access_routes.clear();
+        target_access_definition
+            .access_routes
+            .append(&mut access_routes);
+        new_access_definitions.push(target_access_definition);
+        scope_attribute.access_definitions = new_access_definitions;
+        repository.update_attribute(&scope_attribute);
+    } else {
+        // If no access definitions are established for the given owner address, then the request is
+        // invalid and should be rejected
+        return ContractError::InvalidAddress {
+            address: msg.owner_address,
+            explanation: format!("Scope attribute for address [{scope_address}] does not have access definitions for specified owner"),
+        }.to_err();
+    }
+    Response::new()
+        .add_attributes(
+            EventAttributes::new(EventType::UpdateAccessRoutes)
+                .set_asset_type(&scope_attribute.asset_type)
+                .set_scope_address(&scope_address)
+                .set_new_value(access_routes.len()),
+        )
+        .add_messages(repository.get_messages())
+        .to_ok()
+}

--- a/src/testutil/mod.rs
+++ b/src/testutil/mod.rs
@@ -7,4 +7,6 @@ pub mod test_constants;
 #[cfg(feature = "enable-test-utils")]
 pub mod test_utilities;
 #[cfg(feature = "enable-test-utils")]
+pub mod update_access_routes_helpers;
+#[cfg(feature = "enable-test-utils")]
 pub mod verify_asset_helpers;

--- a/src/testutil/onboard_asset_helpers.rs
+++ b/src/testutil/onboard_asset_helpers.rs
@@ -7,15 +7,13 @@ use cosmwasm_std::testing::mock_info;
 use cosmwasm_std::{coin, MessageInfo};
 
 use super::test_constants::{
-    DEFAULT_ASSET_TYPE, DEFAULT_CONTRACT_BASE_NAME, DEFAULT_ONBOARDING_COST,
-    DEFAULT_ONBOARDING_DENOM, DEFAULT_SCOPE_ADDRESS, DEFAULT_SENDER_ADDRESS,
-    DEFAULT_VERIFIER_ADDRESS,
+    DEFAULT_ASSET_TYPE, DEFAULT_ONBOARDING_COST, DEFAULT_ONBOARDING_DENOM, DEFAULT_SCOPE_ADDRESS,
+    DEFAULT_SENDER_ADDRESS, DEFAULT_VERIFIER_ADDRESS,
 };
 use super::test_utilities::{get_default_access_routes, intercept_add_attribute};
 
 pub struct TestOnboardAsset {
     pub info: MessageInfo,
-    pub contract_base_name: String,
     pub onboard_asset: OnboardAssetV1,
 }
 impl TestOnboardAsset {
@@ -61,7 +59,6 @@ impl Default for TestOnboardAsset {
                     DEFAULT_ONBOARDING_DENOM.to_string(),
                 )],
             ),
-            contract_base_name: DEFAULT_CONTRACT_BASE_NAME.to_string(),
             onboard_asset: TestOnboardAsset::default_onboard_asset(),
         }
     }

--- a/src/testutil/update_access_routes_helpers.rs
+++ b/src/testutil/update_access_routes_helpers.rs
@@ -1,0 +1,8 @@
+use crate::execute::update_access_routes::UpdateAccessRoutesV1;
+use cosmwasm_std::MessageInfo;
+
+pub struct TestUpdateAccessRoutes {
+    pub info: MessageInfo,
+    pub update_access_definitions: UpdateAccessRoutesV1,
+}
+impl TestUpdateAccessRoutes {}

--- a/src/testutil/update_access_routes_helpers.rs
+++ b/src/testutil/update_access_routes_helpers.rs
@@ -8,7 +8,6 @@ use crate::testutil::test_constants::{
 use crate::testutil::test_utilities::{empty_mock_info, intercept_add_attribute, MockOwnedDeps};
 use crate::util::aliases::EntryPointResponse;
 use crate::util::traits::OptionExtensions;
-use cosmwasm_std::testing::mock_info;
 use cosmwasm_std::MessageInfo;
 
 pub struct TestUpdateAccessRoutes {

--- a/src/testutil/update_access_routes_helpers.rs
+++ b/src/testutil/update_access_routes_helpers.rs
@@ -1,8 +1,54 @@
-use crate::execute::update_access_routes::UpdateAccessRoutesV1;
+use crate::core::types::access_route::AccessRoute;
+use crate::core::types::asset_identifier::AssetIdentifier;
+use crate::execute::update_access_routes::{update_access_routes, UpdateAccessRoutesV1};
+use crate::service::asset_meta_service::AssetMetaService;
+use crate::testutil::test_constants::{
+    DEFAULT_ADMIN_ADDRESS, DEFAULT_SCOPE_ADDRESS, DEFAULT_SENDER_ADDRESS,
+};
+use crate::testutil::test_utilities::{empty_mock_info, intercept_add_attribute, MockOwnedDeps};
+use crate::util::aliases::EntryPointResponse;
+use crate::util::traits::OptionExtensions;
+use cosmwasm_std::testing::mock_info;
 use cosmwasm_std::MessageInfo;
 
 pub struct TestUpdateAccessRoutes {
     pub info: MessageInfo,
-    pub update_access_definitions: UpdateAccessRoutesV1,
+    pub update_access_routes: UpdateAccessRoutesV1,
 }
-impl TestUpdateAccessRoutes {}
+impl TestUpdateAccessRoutes {
+    pub fn default_update_access_routes() -> UpdateAccessRoutesV1 {
+        UpdateAccessRoutesV1::new(
+            AssetIdentifier::scope_address(DEFAULT_SCOPE_ADDRESS),
+            DEFAULT_SENDER_ADDRESS,
+            vec![AccessRoute::new(
+                "http://updated.route:8080",
+                "new-location".to_some(),
+            )],
+        )
+    }
+}
+impl Default for TestUpdateAccessRoutes {
+    fn default() -> Self {
+        Self {
+            info: empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+            update_access_routes: TestUpdateAccessRoutes::default_update_access_routes(),
+        }
+    }
+}
+
+pub fn test_update_access_routes(
+    deps: &mut MockOwnedDeps,
+    msg: TestUpdateAccessRoutes,
+) -> EntryPointResponse {
+    let response = update_access_routes(
+        AssetMetaService::new(deps.as_mut()),
+        msg.info,
+        msg.update_access_routes,
+    );
+    intercept_add_attribute(
+        deps,
+        &response,
+        "failure occurred for test_update_access_routes",
+    );
+    response
+}

--- a/src/util/event_attributes.rs
+++ b/src/util/event_attributes.rs
@@ -13,6 +13,7 @@ pub enum EventType {
     ToggleAssetDefinition,
     AddAssetVerifier,
     UpdateAssetVerifier,
+    UpdateAccessRoutes,
 }
 #[allow(clippy::from_over_into)]
 impl Into<String> for EventType {
@@ -27,6 +28,7 @@ impl Into<String> for EventType {
             EventType::ToggleAssetDefinition => "toggle_asset_definition",
             EventType::AddAssetVerifier => "add_asset_verifier",
             EventType::UpdateAssetVerifier => "update_asset_verifier",
+            EventType::UpdateAccessRoutes => "update_access_routes",
         }
         .into()
     }

--- a/src/validation/validate_execute_msg.rs
+++ b/src/validation/validate_execute_msg.rs
@@ -1,5 +1,6 @@
 use crate::core::error::ContractError;
 use crate::core::msg::ExecuteMsg;
+use crate::core::types::access_route::AccessRoute;
 use crate::core::types::asset_identifier::AssetIdentifier;
 use crate::core::types::verifier_detail::VerifierDetail;
 use crate::util::aliases::AssetResult;
@@ -34,6 +35,11 @@ pub fn validate_execute_msg(msg: &ExecuteMsg) -> AssetResult<()> {
             asset_type,
             verifier,
         } => validate_asset_verifier_msg(asset_type, verifier),
+        ExecuteMsg::UpdateAccessRoutes {
+            identifier,
+            owner_address,
+            access_routes,
+        } => validate_update_access_routes(identifier, owner_address, access_routes),
     }
 }
 
@@ -120,6 +126,14 @@ fn validate_asset_verifier_msg(asset_type: &str, verifier: &VerifierDetail) -> A
         None
     };
     validate_verifier_with_provided_errors(verifier, errors)
+}
+
+fn validate_update_access_routes(
+    identifier: &AssetIdentifier,
+    owner_address: &str,
+    access_routes: &[AccessRoute],
+) -> AssetResult<()> {
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR adds a new route called `UpdateAccessRoutes` that allows the owner of access routes on a scope attribute (or the admin account) to update access routes.  This completely replaces the existing access routes on the scope attribute with the values provided, so it should be used carefully (or with a super dope UI somebody makes or something).  This is an expensive route (10 hash in fees) because it requires a delete/add attribute due to there not being update_attribute in provwsam yet :(

Brings the total size of the wasm to a whopping exact 500Kb.  Only 100Kb left until we have to figure something out.