### PR TITLE
Add ExecuteMsg::BindContractAlias

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "0.0.15"
+version = "0.0.16"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "0.0.15"
+version = "0.0.16"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -220,6 +220,26 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "bind_contract_alias"
+      ],
+      "properties": {
+        "bind_contract_alias": {
+          "type": "object",
+          "required": [
+            "alias_name"
+          ],
+          "properties": {
+            "alias_name": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,7 @@
 use crate::core::msg::{ExecuteMsg, InitMsg, MigrateMsg, QueryMsg};
 use crate::execute::add_asset_definition::{add_asset_definition, AddAssetDefinitionV1};
 use crate::execute::add_asset_verifier::{add_asset_verifier, AddAssetVerifierV1};
+use crate::execute::bind_contract_alias::{bind_contract_alias, BindContractAliasV1};
 use crate::execute::onboard_asset::{onboard_asset, OnboardAssetV1};
 use crate::execute::toggle_asset_definition::{toggle_asset_definition, ToggleAssetDefinitionV1};
 use crate::execute::update_access_routes::{update_access_routes, UpdateAccessRoutesV1};
@@ -84,6 +85,9 @@ pub fn execute(deps: DepsMutC, env: Env, info: MessageInfo, msg: ExecuteMsg) -> 
             info,
             UpdateAccessRoutesV1::from_execute_msg(msg)?,
         ),
+        ExecuteMsg::BindContractAlias { .. } => {
+            bind_contract_alias(deps, env, info, BindContractAliasV1::from_execute_msg(msg)?)
+        }
     }
 }
 

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -54,6 +54,9 @@ pub enum ExecuteMsg {
         owner_address: String,
         access_routes: Vec<AccessRoute>,
     },
+    BindContractAlias {
+        alias_name: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -70,7 +70,7 @@ pub fn asset_definitions<'a>(
     IndexedMap::new("asset_definitions", indexes)
 }
 
-/// Inserts a new asset definition into storage.  
+/// Inserts a new asset definition into storage.
 /// If a value already exists, an error will be returned.
 /// Note: Asset definitions must contain a unique asset_type value,
 /// as well as a unique scope_spec_address.  Either unique constraint being

--- a/src/execute/bind_contract_alias.rs
+++ b/src/execute/bind_contract_alias.rs
@@ -1,0 +1,198 @@
+use crate::core::error::ContractError;
+use crate::core::msg::ExecuteMsg;
+use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
+use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
+use crate::util::event_attributes::{EventAttributes, EventType};
+use crate::util::traits::ResultExtensions;
+use cosmwasm_std::{Env, MessageInfo, Response};
+use provwasm_std::{bind_name, NameBinding};
+
+#[derive(Clone, PartialEq)]
+pub struct BindContractAliasV1 {
+    pub alias_name: String,
+}
+impl BindContractAliasV1 {
+    pub fn new<S: Into<String>>(alias_name: S) -> Self {
+        Self {
+            alias_name: alias_name.into(),
+        }
+    }
+
+    pub fn from_execute_msg(msg: ExecuteMsg) -> AssetResult<BindContractAliasV1> {
+        match msg {
+            ExecuteMsg::BindContractAlias { alias_name } => {
+                BindContractAliasV1::new(alias_name).to_ok()
+            }
+            _ => ContractError::InvalidMessageType {
+                expected_message_type: "ExecuteMsg::BindContractAlias".to_string(),
+            }
+            .to_err(),
+        }
+    }
+}
+
+/// Route implementation for ExecuteMsg::BindContractAlias.
+/// This function allows the contract to bind a name to itself using the admin address.
+/// Note: Due to the way Provenance names work, this route will only work when attempting to self-bind
+/// to an unrestricted parent name.  Binding an alias to a restricted parent name will still require
+/// that the address that owns the parent name signs the name binding message.
+pub fn bind_contract_alias(
+    deps: DepsMutC,
+    env: Env,
+    info: MessageInfo,
+    msg: BindContractAliasV1,
+) -> EntryPointResponse {
+    check_admin_only(&deps.as_ref(), &info)?;
+    check_funds_are_empty(&info)?;
+    Response::new()
+        .add_attributes(
+            EventAttributes::new(EventType::BindContractAlias).set_new_value(&msg.alias_name),
+        )
+        .add_message(bind_name(
+            &msg.alias_name,
+            env.contract.address,
+            NameBinding::Restricted,
+        )?)
+        .to_ok()
+}
+
+#[cfg(test)]
+#[cfg(feature = "enable-test-utils")]
+mod tests {
+    use crate::contract::execute;
+    use crate::core::error::ContractError;
+    use crate::core::msg::ExecuteMsg;
+    use crate::execute::bind_contract_alias::{bind_contract_alias, BindContractAliasV1};
+    use crate::testutil::test_constants::DEFAULT_ADMIN_ADDRESS;
+    use crate::testutil::test_utilities::{
+        empty_mock_info, mock_info_with_funds, single_attribute_for_key, test_instantiate_success,
+        InstArgs,
+    };
+    use crate::util::aliases::EntryPointResponse;
+    use crate::util::constants::{ASSET_EVENT_TYPE_KEY, NEW_VALUE_KEY};
+    use crate::util::event_attributes::EventType;
+    use cosmwasm_std::testing::{mock_env, MOCK_CONTRACT_ADDR};
+    use cosmwasm_std::{coin, CosmosMsg};
+    use provwasm_mocks::mock_dependencies;
+    use provwasm_std::{NameMsgParams, ProvenanceMsg, ProvenanceMsgParams};
+
+    #[test]
+    fn test_valid_bind_contract_alias_via_execute() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        test_valid_response(
+            execute(
+                deps.as_mut(),
+                mock_env(),
+                empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+                ExecuteMsg::BindContractAlias {
+                    alias_name: "somealias.pb".to_string(),
+                },
+            ),
+            "somealias.pb",
+        );
+    }
+
+    #[test]
+    fn test_valid_bind_contract_alias_via_direct() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        test_valid_response(
+            bind_contract_alias(
+                deps.as_mut(),
+                mock_env(),
+                empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+                BindContractAliasV1::new("anotheralias.pio"),
+            ),
+            "anotheralias.pio",
+        );
+    }
+
+    #[test]
+    fn test_invalid_bind_contract_alias_for_non_admin_sender() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        let err = bind_contract_alias(
+            deps.as_mut(),
+            mock_env(),
+            empty_mock_info("some-other-guy"),
+            BindContractAliasV1::new("aliasnamething.test"),
+        )
+        .expect_err(
+            "expected an error to occur when attempting to bind an alias using a non-admin account",
+        );
+        assert!(
+            matches!(err, ContractError::Unauthorized { .. }),
+            "unexpected error emitted when using a non-admin account to bind an alias: {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn test_invalid_bind_contract_alias_for_funds_provided() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        let err = bind_contract_alias(
+            deps.as_mut(),
+            mock_env(),
+            mock_info_with_funds(DEFAULT_ADMIN_ADDRESS, &[coin(150, "nhash")]),
+            BindContractAliasV1::new("google.com"),
+        )
+        .expect_err(
+            "expected an error to occur when attempting to bind an alias and sending funds",
+        );
+        assert!(
+            matches!(err, ContractError::InvalidFunds(..)),
+            "unexpected error emitted when sending funds to bind an alias: {:?}",
+            err,
+        );
+    }
+
+    fn test_valid_response<S: Into<String>>(response: EntryPointResponse, expected_bound_name: S) {
+        let response = response.expect("expected binding the alias to succeed");
+        let expected_alias: String = expected_bound_name.into();
+        assert_eq!(
+            1,
+            response.messages.len(),
+            "expected the correct amount of messages to be added",
+        );
+        match &response.messages.first().unwrap().msg {
+            CosmosMsg::Custom(ProvenanceMsg {
+                params:
+                    ProvenanceMsgParams::Name(NameMsgParams::BindName {
+                        name,
+                        address,
+                        restrict,
+                    }),
+                ..
+            }) => {
+                assert_eq!(
+                    &expected_alias, name,
+                    "expected the correct name to be bound",
+                );
+                assert_eq!(
+                    MOCK_CONTRACT_ADDR,
+                    address.as_str(),
+                    "expected the contract's address to be bound to the name",
+                );
+                assert!(restrict, "expected the alias address to be restricted",);
+            }
+            msg => panic!("unexpected message encountered after bind alias: {:?}", msg),
+        }
+        assert_eq!(
+            2,
+            response.attributes.len(),
+            "expected the correct number of attributes to be added",
+        );
+        assert_eq!(
+            EventType::BindContractAlias.event_name(),
+            single_attribute_for_key(&response, ASSET_EVENT_TYPE_KEY),
+            "expected the correct event type attribute to be added",
+        );
+        assert_eq!(
+            expected_alias,
+            single_attribute_for_key(&response, NEW_VALUE_KEY),
+            "expected the correct new value attribute to be added",
+        );
+    }
+}

--- a/src/execute/mod.rs
+++ b/src/execute/mod.rs
@@ -1,5 +1,6 @@
 pub mod add_asset_definition;
 pub mod add_asset_verifier;
+pub mod bind_contract_alias;
 pub mod onboard_asset;
 pub mod toggle_asset_definition;
 pub mod update_access_routes;

--- a/src/util/event_attributes.rs
+++ b/src/util/event_attributes.rs
@@ -14,6 +14,7 @@ pub enum EventType {
     AddAssetVerifier,
     UpdateAssetVerifier,
     UpdateAccessRoutes,
+    BindContractAlias,
 }
 #[allow(clippy::from_over_into)]
 impl Into<String> for EventType {
@@ -29,6 +30,7 @@ impl Into<String> for EventType {
             EventType::AddAssetVerifier => "add_asset_verifier",
             EventType::UpdateAssetVerifier => "update_asset_verifier",
             EventType::UpdateAccessRoutes => "update_access_routes",
+            EventType::BindContractAlias => "bind_contract_alias",
         }
         .into()
     }


### PR DESCRIPTION
# Feature
This PR adds a new `bind_contract_alias` execution route for the contract.  This allows the contract to bind an alias to itself (using an unrestricted parent name).  This to allow the contract to pin as many alias names as needed after instantiation for easy resolution.

# Tweaks
- Bump version to v0.0.16
- Add helper function `gen_validation_response` to `validate_execute_msg.rs` that makes the function declarations there more concise.