### PR TITLE
Feature: Allow contract admin swap on migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "1.0.0"
+version = "1.0.1"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/schema/migrate_msg.json
+++ b/schema/migrate_msg.json
@@ -9,10 +9,37 @@
       ],
       "properties": {
         "contract_upgrade": {
-          "type": "object"
+          "type": "object",
+          "properties": {
+            "options": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/MigrationOptions"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
         }
       },
       "additionalProperties": false
     }
-  ]
+  ],
+  "definitions": {
+    "MigrationOptions": {
+      "description": "Sub-level struct that defines optional changes that can occur during the migration process.",
+      "type": "object",
+      "properties": {
+        "new_admin_address": {
+          "description": "Sets the contract admin to a new address",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -96,6 +96,6 @@ pub fn execute(deps: DepsMutC, env: Env, info: MessageInfo, msg: ExecuteMsg) -> 
 #[entry_point]
 pub fn migrate(deps: DepsMutC, _env: Env, msg: MigrateMsg) -> EntryPointResponse {
     match msg {
-        MigrateMsg::ContractUpgrade {} => migrate_contract(deps),
+        MigrateMsg::ContractUpgrade { options } => migrate_contract(deps, options),
     }
 }

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -81,5 +81,19 @@ pub enum QueryMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MigrateMsg {
-    ContractUpgrade {},
+    ContractUpgrade { options: Option<MigrationOptions> },
+}
+
+/// Sub-level struct that defines optional changes that can occur during the migration process.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct MigrationOptions {
+    /// Sets the contract admin to a new address
+    pub new_admin_address: Option<String>,
+}
+impl MigrationOptions {
+    /// Notes whether or not any options have been specified
+    pub fn has_changes(&self) -> bool {
+        self.new_admin_address.is_some()
+    }
 }

--- a/src/migrate/migrate_contract.rs
+++ b/src/migrate/migrate_contract.rs
@@ -25,6 +25,7 @@ pub fn migrate_contract(deps: DepsMutC, options: Option<MigrationOptions>) -> En
     let new_version_info = migrate_version_info(deps.storage)?;
     let mut additional_metadata = EventAdditionalMetadata::new();
     if let Some(options) = options {
+        // Only load and update the state if any options have actually been specified
         if options.has_changes() {
             let mut state_storage = config_v2(deps.storage);
             let mut state = state_storage.load()?;

--- a/src/migrate/migrate_contract.rs
+++ b/src/migrate/migrate_contract.rs
@@ -1,6 +1,10 @@
 use cosmwasm_std::{Response, Storage};
 use semver::Version;
 
+use crate::core::msg::MigrationOptions;
+use crate::core::state::config_v2;
+use crate::util::event_attributes::EventAdditionalMetadata;
+use crate::util::scope_address_utils::bech32_string_to_addr;
 use crate::{
     core::error::ContractError,
     util::{
@@ -14,15 +18,31 @@ use super::version_info::{
     get_version_info, migrate_version_info, CONTRACT_NAME, CONTRACT_VERSION,
 };
 
-pub fn migrate_contract(deps: DepsMutC) -> EntryPointResponse {
+pub fn migrate_contract(deps: DepsMutC, options: Option<MigrationOptions>) -> EntryPointResponse {
     // Ensure the migration is not attempting to revert to an old version or something crazier
     check_valid_migration_versioning(deps.storage)?;
     // Store the new version info
     let new_version_info = migrate_version_info(deps.storage)?;
+    let mut additional_metadata = EventAdditionalMetadata::new();
+    if let Some(options) = options {
+        if options.has_changes() {
+            let mut state_storage = config_v2(deps.storage);
+            let mut state = state_storage.load()?;
+            if let Some(new_admin_address) = options.new_admin_address {
+                // Only set a new specified admin if it is a legitimate bech32 Provenance Blockchain address
+                state.admin = bech32_string_to_addr(&new_admin_address)?;
+                additional_metadata.add_metadata("new_admin_address", &new_admin_address);
+            }
+            // Persist all changes to the state
+            state_storage.save(&state)?;
+        }
+    }
     Response::new()
         .add_attributes(
             EventAttributes::new(EventType::MigrateContract)
-                .set_new_value(&new_version_info.version),
+                .set_new_value(&new_version_info.version)
+                // Note: If additional metadata is empty, it will not be appended as an attribute
+                .set_additional_metadata(&additional_metadata),
         )
         .to_ok()
 }
@@ -57,6 +77,10 @@ fn check_valid_migration_versioning(storage: &mut dyn Storage) -> AssetResult<()
 mod tests {
     use provwasm_mocks::mock_dependencies;
 
+    use crate::core::state::config_read_v2;
+    use crate::testutil::test_utilities::{test_instantiate_success, InstArgs};
+    use crate::util::constants::ADDITIONAL_METADATA_KEY;
+    use crate::util::traits::OptionExtensions;
     use crate::{
         migrate::version_info::{set_version_info, VersionInfoV1},
         testutil::test_utilities::single_attribute_for_key,
@@ -76,7 +100,7 @@ mod tests {
             },
         )
         .expect("setting the initial version info should not fail");
-        let response = migrate_contract(deps.as_mut()).expect(
+        let response = migrate_contract(deps.as_mut(), None).expect(
             "a migration should be successful when the contract is migrating to a new version",
         );
         assert!(
@@ -101,6 +125,62 @@ mod tests {
     }
 
     #[test]
+    fn test_successful_migration_with_admin_change() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        set_version_info(
+            deps.as_mut().storage,
+            &VersionInfoV1 {
+                contract: CONTRACT_NAME.to_string(),
+                version: "0.0.0".to_string(),
+            },
+        )
+        .expect("setting the initial version info should not fail");
+        let new_admin_address = "tp1hsqtppgy7mgd64q0uvk7q39qa7h8hp30urqs6n";
+        let response = migrate_contract(
+            deps.as_mut(),
+            MigrationOptions {
+                // Address randomly generated externally
+                new_admin_address: new_admin_address.to_string().to_some(),
+            }
+            .to_some(),
+        )
+        .expect("expected a new admin address with correct bech32 specification to succeed");
+        assert!(
+            response.messages.is_empty(),
+            "a migration should not produce messages, and they would be ignored",
+        );
+        assert_eq!(
+            3,
+            response.attributes.len(),
+            "the migration should produce the correct number of attributes",
+        );
+        assert_eq!(
+            EventType::MigrateContract.event_name().as_str(),
+            single_attribute_for_key(&response, ASSET_EVENT_TYPE_KEY),
+            "the proper event type attribute should be emitted",
+        );
+        assert_eq!(
+            CONTRACT_VERSION,
+            single_attribute_for_key(&response, NEW_VALUE_KEY),
+            "the new value key should equate to the current contract version",
+        );
+        assert_eq!(
+            format!("[new_admin_address={new_admin_address}]"),
+            single_attribute_for_key(&response, ADDITIONAL_METADATA_KEY),
+            "the additional metadata should specify the new admin address",
+        );
+        let state = config_read_v2(deps.as_ref().storage)
+            .load()
+            .expect("expected the contract config to load without issue");
+        assert_eq!(
+            new_admin_address,
+            state.admin.as_str(),
+            "expected the new admin address to be persisted in the contract state",
+        );
+    }
+
+    #[test]
     fn test_failed_migration_for_incorrect_name() {
         let mut deps = mock_dependencies(&[]);
         set_version_info(
@@ -111,7 +191,7 @@ mod tests {
             },
         )
         .unwrap();
-        let error = migrate_contract(deps.as_mut()).unwrap_err();
+        let error = migrate_contract(deps.as_mut(), None).unwrap_err();
         match error {
             ContractError::InvalidContractName {
                 current_contract,
@@ -143,7 +223,7 @@ mod tests {
             },
         )
         .unwrap();
-        let error = migrate_contract(deps.as_mut()).unwrap_err();
+        let error = migrate_contract(deps.as_mut(), None).unwrap_err();
         match error {
             ContractError::InvalidContractVersion {
                 current_version,
@@ -162,5 +242,33 @@ mod tests {
             }
             _ => panic!("unexpected error encountered: {:?}", error),
         };
+    }
+
+    #[test]
+    fn test_failed_migration_for_invalid_new_admin_address() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        set_version_info(
+            deps.as_mut().storage,
+            &VersionInfoV1 {
+                contract: CONTRACT_NAME.to_string(),
+                version: "0.0.0".to_string(),
+            },
+        )
+        .expect("overriding version info should not fail");
+        let error = migrate_contract(
+            deps.as_mut(),
+            MigrationOptions {
+                new_admin_address: "not a bech32 thing that's for sure".to_string().to_some(),
+            }
+            .to_some(),
+        )
+        .expect_err(
+            "expected an error to occur when using a non-bech32 address as the new admin address",
+        );
+        assert!(
+            matches!(error, ContractError::Bech32Error(_)),
+            "expected a bech32 error to occur when an invalid bech32 address was provided as the new admin",
+        );
     }
 }

--- a/src/util/constants.rs
+++ b/src/util/constants.rs
@@ -26,6 +26,8 @@ pub const ASSET_TYPE_KEY: &str = "asset_type";
 pub const VERIFIER_ADDRESS_KEY: &str = "asset_verifier_address";
 /// Value = Any new value being changed that can be coerced to a string target. Dynamic to be used on various routes (String)
 pub const NEW_VALUE_KEY: &str = "asset_new_value";
+/// Value = EventAdditionalMetadata meta string
+pub const ADDITIONAL_METADATA_KEY: &str = "asset_additional_metadata";
 
 //////////////////////
 // Global Constants //


### PR DESCRIPTION
# Description
This change allows the contract admin address to be changed during a migration.  This ensure that the only the contract admin on the blockchain can swap the contract's internal admin address.  Ideally, these two should always match, but that's not possible to fully enforce in a way that maintains 1 to 1 parity with the external admin.

# Features
- Adds a new `MigrationOptions` to the migrate msg.  This allows many sub-fields to be added instead of clogging up the function definitions whenever a new param needs to be added.
- Swap the contract admin address when a valid bech32 is provided in the `new_contract_admin` param of `MigrationOptions` during the `migrate` function.
- Adds a new `EventAdditionalMetadata` dynamic struct to the `EventAttributes` struct's keys.  This allows un-keyed values to be specified in the attributes when they are non-vital values that don't need their own root-level attribute key.