### PR TITLE
Refactor: AssetDefinitionV2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "1.0.2"
+version = "1.0.3"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/README.md
+++ b/README.md
@@ -60,19 +60,19 @@ meant to be an exhaustive list of all different types of accounts that may have 
 the sender address is automatically used as the admin.  This account is required to execute many of the
 contract execution endpoints.  This address can later be changed when running a contract migration.
 
-* __Verifier Account__: This account type is used in the contract's [AssetDefinition](src/core/types/asset_definition.rs)'s
-[VerifierDetail](src/core/types/verifier_detail.rs).  It indicates an account that will inspect the events emitted by
+* __Verifier Account__: This account type is used in the contract's [AssetDefinitionV2](src/core/types/asset_definition.rs)'s
+[VerifierDetailV2](src/core/types/verifier_detail.rs).  It indicates an account that will inspect the events emitted by
 the contract, receive all or a portion of the fees sent to the contract during the onboarding process, and perform
 verification of an underlying scope.  Eventually, this account is tasked with calling into the [Verify Asset](src/execute/verify_asset.rs)
 execution route to specify whether or not an onboarded scope is valid and therefore verified.
 
 * __Onboarding Account__: This account is not stored in the contract, and can be any Provenance Blockchain address.  It
 is the primary consumer of the contract's functionality, and calls into the [Onboard Asset](src/execute/onboard_asset.rs)
-execution route, specifying a Verifier Account and paying the fees required by the verifier's [VerifierDetail](src/core/types/verifier_detail.rs).
+execution route, specifying a Verifier Account and paying the fees required by the verifier's [VerifierDetailV2](src/core/types/verifier_detail.rs).
 
-* __Fee Account__: This account is an optional specification in a [VerifierDetail](src/core/types/verifier_detail.rs) and,
+* __Fee Account__: This account is an optional specification in a [VerifierDetailV2](src/core/types/verifier_detail.rs) and,
 when specified, indicates that some or all of the fees provided during the onboarding process should be sent to this address.
-The fee account is specified directly in a [FeeDestination](src/core/types/fee_destination.rs), nested within the [VerifierDetail](src/core/types/verifier_detail.rs).
+The fee account is specified directly in a [FeeDestinationV2](src/core/types/fee_destination.rs), nested within the [VerifierDetailV2](src/core/types/verifier_detail.rs).
 There can be multiple Fee Accounts for a single Verifier Account, ensuring that any amount of fee division can occur.
 
 ## Contract Interaction
@@ -87,7 +87,7 @@ When the contract is instantiated, it does the following actions:
 based on an input value.  This can be omitted if the contract does not want to actually bind its root name.  This
 circumstance can arise if the root name of the contract already exists, or if it is restricted.
 
-* Optionally establishes an initial set of [AssetDefinition](src/core/types/asset_definition.rs) values if any are
+* Optionally establishes an initial set of [AssetDefinitionV2](src/core/types/asset_definition.rs) values if any are
 provided, and binds their names, also optionally.  The names bound will be their asset types, branched from the contract's
 base name value.
 
@@ -100,7 +100,7 @@ later during a contract migration.
 #### Request Parameters
 
 * `base_contract_name`: This name serves as the basis for all generated [Provenance Attributes](https://docs.provenance.io/modules/account).
-All [AssetDefinition](src/core/types/asset_definition.rs) names established will use this name as the root value.
+All [AssetDefinitionV2](src/core/types/asset_definition.rs) names established will use this name as the root value.
 For instance, if the `base_contract_name` is `testasset` and an asset definition's `asset_type` is specified as `donut`,
 then the attribute name used for created [AssetScopeAttributes](src/core/types/asset_scope_attribute.rs) will be
 `donut.testasset`.
@@ -110,10 +110,10 @@ provided name uses a restricted root name, so using a value of `false` can circu
 bound later or potentially not at all.  The contract needs to own the subnames used for generated attributes in order
 for its bindings to work, but owning the root name is not necessary.
 
-* `asset_definitions`: An array of [AssetDefinitionInput](src/core/types/asset_definition.rs) values that will be used
-to establish an initial set of [AssetDefinition](src/core/types/asset_definition.rs)s in the contract's internal storage.
+* `asset_definitions`: An array of [AssetDefinitionInputV2](src/core/types/asset_definition.rs) values that will be used
+to establish an initial set of [AssetDefinitionV2](src/core/types/asset_definition.rs)s in the contract's internal storage.
 These definitions will automatically attempt to bind their own names, branching from the `base_contract_name`, but the
-[AssetDefinitionInput](src/core/types/asset_definition.rs) includes a `bind_name` boolean that allows this functionality
+[AssetDefinitionInputV2](src/core/types/asset_definition.rs) includes a `bind_name` boolean that allows this functionality
 to be disabled if that behavior is not desired.
 
 * `is_test`: A boolean value allowing for less restrictions to be placed on certain functionalities across the contract's
@@ -140,11 +140,11 @@ underlying record values.  This should never be set to true in a mainnet environ
           "address": "tp14w3jf4em4uszs77yaqnmfrlxwcmqux5g6hfpdf",
           "onboarding_cost": "150",
           "onboarding_denom": "nhash",
-          "fee_percent": "0.5",
+          "fee_amount": "75",
           "fee_destinations": [
             {
               "address": "tp1u7r46zkgcmvel59tqa9352k5rycl985ywqnjp7",
-              "fee_percent": "1.0"
+              "fee_amount": "75"
             }
           ],
           "entity_detail": {
@@ -224,7 +224,7 @@ asset corresponding to that scope (heloc, mortgage, payable, etc), and, if all c
 provided scope that stages the scope for verification of authenticity by the specified verifier in the request.  The
 attribute is attached based on the `base_contract_name` specified in the contract, combined with the specified asset type
 in the request.  Ex: if `base_contract_name` is "asset" and the asset type is "myasset", the attribute would be assigned
-under the name of "myasset.asset".  All available asset types are queryable, and stored in the contract as [AssetDefinition](src/core/types/asset_definition.rs)
+under the name of "myasset.asset".  All available asset types are queryable, and stored in the contract as [AssetDefinitionV2](src/core/types/asset_definition.rs)
 values.  After onboarding is completed, an [AssetScopeAttribute](src/core/types/asset_scope_attribute.rs) will be
 stored on the scope with an [AssetOnboardingStatus](src/core/types/asset_onboarding_status.rs) of `Pending`, indicating
 that the asset has been onboarded to the contract but is awaiting verification.
@@ -244,11 +244,11 @@ OR
 {"identifier": {"type": "scope_address", "value": "scope1qzj8tjp76mn3rmyvz49c5738k2asm824ga"}}
 ```
 
-* `asset_type`: A name that must directly match one of the contract's internal [AssetDefinition](src/core/types/asset_definition.rs)
+* `asset_type`: A name that must directly match one of the contract's internal [AssetDefinitionV2](src/core/types/asset_definition.rs)
 names.  Any request with a specified type not matching an asset definition will be rejected outright.
 
-* `verifier_address`: The bech32 address of a Verifier Account associated with the targeted [AssetDefinition](src/core/types/asset_definition.rs),
-within its nested vector of [VerifierDetail](src/core/types/verifier_detail.rs)s.
+* `verifier_address`: The bech32 address of a Verifier Account associated with the targeted [AssetDefinitionV2](src/core/types/asset_definition.rs),
+within its nested vector of [VerifierDetailV2](src/core/types/verifier_detail.rs)s.
 
 * `access_routes`: An optional parameter that allows the specification of a location to get the underlying asset data
 for the specified scope.  The [AccessRoute](src/core/types/access_route.rs) struct is very generic in its composition
@@ -366,7 +366,7 @@ attached to the scope that was previously onboarded before verification.
 
 #### [Add Asset Definition](src/execute/add_asset_definition.rs)
 
-__This route is only accessible to the contract's admin address.__  This route allows a new [AssetDefinition](src/core/types/asset_definition.rs)
+__This route is only accessible to the contract's admin address.__  This route allows a new [AssetDefinitionV2](src/core/types/asset_definition.rs)
 value to be added to the contract's internal storage.  These asset definitions dictate which asset types are allowed to
 be onboarded, as well as which verifiers are tied to each asset type.  Each added asset definition must be unique in
 two criteria:
@@ -377,14 +377,14 @@ Additionally, all added asset definitions must refer to an existing [Provenance 
 
 ##### Request Parameters
 
-* `asset_definition`: An [AssetDefinitionInput](src/core/types/asset_definition.rs) value defining all of the new
-[AssetDefinition](src/core/types/asset_definition.rs)'s values.  The execution route converts the incoming value to an
+* `asset_definition`: An [AssetDefinitionInputV2](src/core/types/asset_definition.rs) value defining all of the new
+[AssetDefinitionV2](src/core/types/asset_definition.rs)'s values.  The execution route converts the incoming value to an
 asset definition.
 
 ##### Emitted Attributes
 * `asset_event_type`: This value will always be populated as `add_asset_definition`.
 
-* `asset_type`: This value will be the `asset_type` value stored in the added [AssetDefinition](src/core/types/asset_definition.rs).
+* `asset_type`: This value will be the `asset_type` value stored in the added [AssetDefinitionV2](src/core/types/asset_definition.rs).
 
 ##### Response Sample
 ```json
@@ -401,15 +401,15 @@ asset definition.
           "address": "tp1eqfg2lxlwqs23m320arhuk3dad47ha6tvzu5n5",
           "onboarding_cost": "1000000000",
           "onboarding_denom:": "nhash",
-          "fee_percent": "0.5",
+          "fee_amount": "500000000",
           "fee_destinations": [
             {
               "address": "tp1s735l5tmh7sngyvvn6rf4l7e9e9qq8uz93z9ky",
-              "fee_percent": "0.5"
+              "fee_amount": "500000000"
             },
             {
               "address": "tp1k5m8lkshpupuf44p02r4mwgjdawd2kta4n9ry0",
-              "fee_percent": "0.5"
+              "fee_amount": "500000000"
             }
           ],
           "entity_detail": {
@@ -428,21 +428,21 @@ asset definition.
 ```
 
 #### [Update Asset Definition](src/execute/update_asset_definition.rs)
-__This route is only accessible to the contract's admin address.__ This route allows an existing [AssetDefinition](src/core/types/asset_definition.rs)
+__This route is only accessible to the contract's admin address.__ This route allows an existing [AssetDefinitionV2](src/core/types/asset_definition.rs)
 value to be updated.  It works by matching the input's `asset_type` to an existing asset definition and overwriting the
 existing values.  If no asset definition exists for the given type, the request will be rejected.  Contract validation
 ensures that after the update, all scope specification addresses contained in asset definitions remain unique, as well.
 
 ##### Request Parameters
 
-* `asset_definition`: An [AssetDefinitionInput](src/core/types/asset_definition.rs) value defining all of the updated
-  [AssetDefinition](src/core/types/asset_definition.rs)'s values.  The execution route converts the incoming value to an
+* `asset_definition`: An [AssetDefinitionInputV2](src/core/types/asset_definition.rs) value defining all of the updated
+  [AssetDefinitionV2](src/core/types/asset_definition.rs)'s values.  The execution route converts the incoming value to an
   asset definition.
 
 ##### Emitted Attributes
 * `asset_event_type`: This value will always be populated as `update_asset_definition`.
 
-* `asset_type`: This value will be the `asset_type` value stored in the updated [AssetDefinition](src/core/types/asset_definition.rs).
+* `asset_type`: This value will be the `asset_type` value stored in the updated [AssetDefinitionV2](src/core/types/asset_definition.rs).
 
 ##### Response Sample
 ```json
@@ -459,11 +459,11 @@ ensures that after the update, all scope specification addresses contained in as
           "address": "tp1uvnpfg9hmeyuf0t3a6l9xhegx8ewhtk9z683x4",
           "onboarding_cost": "15000000000",
           "onboarding_denom:": "carcoins",
-          "fee_percent": "0.25",
+          "fee_amount": "20000",
           "fee_destinations": [
             {
               "address": "tp1s735l5tmh7sngyvvn6rf4l7e9e9qq8uz93z9ky",
-              "fee_percent": "1.0"
+              "fee_amount": "20000"
             }
           ],
           "entity_detail": {
@@ -481,7 +481,7 @@ ensures that after the update, all scope specification addresses contained in as
 ```
 
 #### [Toggle Asset Definition](src/execute/toggle_asset_definition.rs)
-__This route is only accessible to the contract's admin address.__ This route toggles an existing [AssetDefinition](src/core/types/asset_definition.rs)
+__This route is only accessible to the contract's admin address.__ This route toggles an existing [AssetDefinitionV2](src/core/types/asset_definition.rs)
 from enabled to disabled, or disabled to enabled.  When disabled, an asset definition will no longer allow new assets to
 be onboarded to the contract.  Existing assets already onboarded to the contract and in pending status will still be
 allowed to be verified, but new values will be rejected.  This same functionality could be achieved with an invocation of
@@ -501,7 +501,7 @@ the asset definition is in the intended state during the execution of the route.
 ##### Emitted Attributes
 * `asset_event_type`: This value will always be populated as `toggle_asset_definition`.
 
-* `asset_type`: This value will be the `asset_type` value stored in the modified [AssetDefinition](src/core/types/asset_definition.rs).
+* `asset_type`: This value will be the `asset_type` value stored in the modified [AssetDefinitionV2](src/core/types/asset_definition.rs).
 
 * `asset_new_value`: This value will be the new status of the asset definition's `enabled` property, after the toggle occurs (true/false).
 
@@ -516,27 +516,27 @@ the asset definition is in the intended state during the execution of the route.
 ```
 
 #### [Add Asset Verifier](src/execute/add_asset_verifier.rs)
-__This route is only accessible to the contract's admin address.__ This route adds a new [VerifierDetail](src/core/types/verifier_detail.rs)
-to an existing [AssetDefinition](src/core/types/asset_definition.rs).  This route is intended to register new verifiers
+__This route is only accessible to the contract's admin address.__ This route adds a new [VerifierDetailV2](src/core/types/verifier_detail.rs)
+to an existing [AssetDefinitionV2](src/core/types/asset_definition.rs).  This route is intended to register new verifiers
 without the bulky requirements of the `UpdateAssetDefinition` execution route.  This route will reject verifiers added
 with addresses that match any other verifiers on the target asset definition.
 
 ##### Request Parameters
 
-* `asset_type`: The type of asset for which the new [VerifierDetail](src/core/types/verifier_detail.rs) will be added.
-This must refer to an existing [AssetDefinition](src/core/types/asset_definition.rs)'s `asset_type` value, or the request
+* `asset_type`: The type of asset for which the new [VerifierDetailV2](src/core/types/verifier_detail.rs) will be added.
+This must refer to an existing [AssetDefinitionV2](src/core/types/asset_definition.rs)'s `asset_type` value, or the request
 will be rejected.
 
-* `verifier`: The new [VerifierDetail](src/core/types/verifier_detail.rs) to be added to the asset definition, with all
+* `verifier`: The new [VerifierDetailV2](src/core/types/verifier_detail.rs) to be added to the asset definition, with all
 of its required values.  No verifiers within the existing asset definition must have the same `address` value of this
 parameter, or the request will be rejected.
 
 ##### Emitted Attributes
 * `asset_event_type`: This value will always be populated as `add_asset_verifier`.
 
-* `asset_type`: This value will be the `asset_type` value stored in the modified [AssetDefinition](src/core/types/asset_definition.rs).
+* `asset_type`: This value will be the `asset_type` value stored in the modified [AssetDefinitionV2](src/core/types/asset_definition.rs).
 
-* `asset_verifier_address`: This value will be the bech32 address stored in the `address` property of the new [VerifierDetail](src/core/types/verifier_detail.rs).
+* `asset_verifier_address`: This value will be the bech32 address stored in the `address` property of the new [VerifierDetailV2](src/core/types/verifier_detail.rs).
 
 ##### Response Sample
 ```json
@@ -547,11 +547,11 @@ parameter, or the request will be rejected.
       "address": "tp149832nekuva7lxtzcezlwhzqjc32vu8lsaqcuv",
       "onboarding_cost": "250",
       "onboarding_denom": "traintoken",
-      "fee_percent": "1.0",
+      "fee_amount": "250",
       "fee_destinations": [
         {
           "address": "tp1lmp2qmntl090whuftym0wthzwjc8xv0v79cu6l",
-          "fee_percent": "1.0"
+          "fee_amount": "250"
         }
       ],
       "entity_detail": {
@@ -566,28 +566,28 @@ parameter, or the request will be rejected.
 ```
 
 #### [Update Asset Verifier](src/execute/update_asset_verifier.rs)
-__This route is only accessible to the contract's admin address.__ This route updates an existing [VerifierDetail](src/core/types/verifier_detail.rs)
-in an existing [AssetDefinition](src/core/types/asset_definition.rs).  This route is intended to be used when the values
+__This route is only accessible to the contract's admin address.__ This route updates an existing [VerifierDetailV2](src/core/types/verifier_detail.rs)
+in an existing [AssetDefinitionV2](src/core/types/asset_definition.rs).  This route is intended to be used when the values
 of a single verifier detail need to change, but not the entire asset definition.  The request will be rejected if the
 referenced asset definition is not present within the contract, or if a verifier does not exist within the asset
 definition that matches the address of the provided verifier data.
 
 ##### Request Parameters
 
-* `asset_type`: The type of asset for which the [VerifierDetail](src/core/types/verifier_detail.rs) will be updated. This
-must refer to an existing [AssetDefinition](src/core/types/asset_definition.rs)'s `asset_type` value, or the request
+* `asset_type`: The type of asset for which the [VerifierDetailV2](src/core/types/verifier_detail.rs) will be updated. This
+must refer to an existing [AssetDefinitionV2](src/core/types/asset_definition.rs)'s `asset_type` value, or the request
 will be rejected.
 
-* `verifier`: The updated [VerifierDetail](src/core/types/verifier_detail.rs) to be modified in the asset definition.
+* `verifier`: The updated [VerifierDetailV2](src/core/types/verifier_detail.rs) to be modified in the asset definition.
 An existing verifier detail within the target asset definition must have a matching `address` value, or the request will
 be rejected.
 
 ##### Emitted Attributes
 * `asset_event_type`: This value will always be populated as `update_asset_verifier`.
 
-* `asset_type`: This value will be the `asset_type` value stored in the modified [AssetDefinition](src/core/types/asset_definition.rs).
+* `asset_type`: This value will be the `asset_type` value stored in the modified [AssetDefinitionV2](src/core/types/asset_definition.rs).
 
-* `asset_verifier_address`: This value will be the bech32 address stored in the `address` property of the updated [VerifierDetail](src/core/types/verifier_detail.rs).
+* `asset_verifier_address`: This value will be the bech32 address stored in the `address` property of the updated [VerifierDetailV2](src/core/types/verifier_detail.rs).
 
 ##### Response Sample
 ```json
@@ -598,7 +598,7 @@ be rejected.
       "address": "tp15n6as7tytrza9692anawwc52kyg5pv86lpeyhu",
       "onboarding_cost": "200",
       "onboarding_denom": "widgetdollar",
-      "fee_percent": "0",
+      "fee_amount": "0",
       "fee_destinations": [],
       "entity_detail": {
         "name": "Widget Verifier Inc.",
@@ -639,7 +639,7 @@ routes need to be included in the request alongside the new route(s).
 ##### Emitted Attributes
 * `asset_event_type`: This value will always be populated as `update_access_routes`.
 
-* `asset_type`: This value will be the `asset_type` value stored in the modified [AssetDefinition](src/core/types/asset_definition.rs).
+* `asset_type`: This value will be the `asset_type` value stored in the modified [AssetDefinitionV2](src/core/types/asset_definition.rs).
 
 * `asset_scope_address`: This value will be the bech32 address of the [Provenance Blockchain Metadata Scope](https://docs.provenance.io/modules/metadata-module#metadata-scope)
 referred to by the `identifier` parameter passed into the execution message.
@@ -698,7 +698,7 @@ defined in the [QueryMsg Enum](src/core/msg.rs).  The json schema for sending a 
 
 #### [Query Asset Definition](src/query/query_asset_definition.rs)
 
-This route can be used to retrieve a specific [AssetDefinition](src/core/types/asset_definition.rs) from the contract's
+This route can be used to retrieve a specific [AssetDefinitionV2](src/core/types/asset_definition.rs) from the contract's
 internal storage for inspection of its verifies and other properties.  If the requested value is not found, a null
 response will be returned.
 
@@ -737,11 +737,15 @@ OR
         "address": "tp1935mawrmyuzwuryg8wya3g6uh2vpwvapq50kvq",
         "onboarding_cost": "1000000000",
         "onboarding_denom": "nhash",
-        "fee_percent": "0.5",
+        "fee_amount": "1234",
         "fee_destinations": [
           {
             "address": "tp126lrty2c0h78mdtjyzzf7mtsge427trccq8lta",
-            "fee_percent": "1.0"
+            "fee_amount": "1000"
+          },
+          {
+            "address": "tp1gkg4a8zrtadlz5c5u56fuhcf5gq3xy4v8pgaef",
+            "fee_amount": "234"
           }
         ],
         "entity_detail": {
@@ -787,11 +791,11 @@ No parameters are used for the `QueryAssetDefinitions` route.
             "address": "tp1935mawrmyuzwuryg8wya3g6uh2vpwvapq50kvq",
             "onboarding_cost": "250",
             "onboarding_denom": "ferretcoin",
-            "fee_percent": "1.0",
+            "fee_amount": "250",
             "fee_destinations": [
               {
                 "address": "tp126lrty2c0h78mdtjyzzf7mtsge427trccq8lta",
-                "fee_percent": "1.0"
+                "fee_amount": "250"
               }
             ],
             "entity_detail": {

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ execution route to specify whether or not an onboarded scope is valid and theref
 
 * __Onboarding Account__: This account is not stored in the contract, and can be any Provenance Blockchain address.  It
 is the primary consumer of the contract's functionality, and calls into the [Onboard Asset](src/execute/onboard_asset.rs)
-execution route, specifying a Verifier Account and paying the fees required by the verifier's [VerifierDetailV2](src/core/types/verifier_detail.rs).
+execution route, specifying a Verifier Account and paying the fees required by the verifier's [fee destinations](src/core/types/fee_destination.rs).
 
 * __Fee Account__: This account is an optional specification in a [VerifierDetailV2](src/core/types/verifier_detail.rs) and,
 when specified, indicates that some or all of the fees provided during the onboarding process should be sent to this address.
@@ -140,7 +140,6 @@ underlying record values.  This should never be set to true in a mainnet environ
           "address": "tp14w3jf4em4uszs77yaqnmfrlxwcmqux5g6hfpdf",
           "onboarding_cost": "150",
           "onboarding_denom": "nhash",
-          "fee_amount": "75",
           "fee_destinations": [
             {
               "address": "tp1u7r46zkgcmvel59tqa9352k5rycl985ywqnjp7",
@@ -405,7 +404,6 @@ asset definition.
           "address": "tp1eqfg2lxlwqs23m320arhuk3dad47ha6tvzu5n5",
           "onboarding_cost": "1000000000",
           "onboarding_denom:": "nhash",
-          "fee_amount": "500000000",
           "fee_destinations": [
             {
               "address": "tp1s735l5tmh7sngyvvn6rf4l7e9e9qq8uz93z9ky",
@@ -467,7 +465,6 @@ ensures that after the update, all scope specification addresses contained in as
           "address": "tp1uvnpfg9hmeyuf0t3a6l9xhegx8ewhtk9z683x4",
           "onboarding_cost": "15000000000",
           "onboarding_denom:": "carcoins",
-          "fee_amount": "20000",
           "fee_destinations": [
             {
               "address": "tp1s735l5tmh7sngyvvn6rf4l7e9e9qq8uz93z9ky",
@@ -559,7 +556,6 @@ parameter, or the request will be rejected.
       "address": "tp149832nekuva7lxtzcezlwhzqjc32vu8lsaqcuv",
       "onboarding_cost": "250",
       "onboarding_denom": "traintoken",
-      "fee_amount": "250",
       "fee_destinations": [
         {
           "address": "tp1lmp2qmntl090whuftym0wthzwjc8xv0v79cu6l",
@@ -615,7 +611,6 @@ be rejected.
       "address": "tp15n6as7tytrza9692anawwc52kyg5pv86lpeyhu",
       "onboarding_cost": "200",
       "onboarding_denom": "widgetdollar",
-      "fee_amount": "0",
       "fee_destinations": [],
       "entity_detail": {
         "name": "Widget Verifier Inc.",
@@ -754,7 +749,6 @@ OR
         "address": "tp1935mawrmyuzwuryg8wya3g6uh2vpwvapq50kvq",
         "onboarding_cost": "1000000000",
         "onboarding_denom": "nhash",
-        "fee_amount": "1234",
         "fee_destinations": [
           {
             "address": "tp126lrty2c0h78mdtjyzzf7mtsge427trccq8lta",
@@ -816,7 +810,6 @@ No parameters are used for the `QueryAssetDefinitions` route.
             "address": "tp1935mawrmyuzwuryg8wya3g6uh2vpwvapq50kvq",
             "onboarding_cost": "250",
             "onboarding_denom": "ferretcoin",
-            "fee_amount": "250",
             "fee_destinations": [
               {
                 "address": "tp126lrty2c0h78mdtjyzzf7mtsge427trccq8lta",

--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ underlying record values.  This should never be set to true in a mainnet environ
           "fee_destinations": [
             {
               "address": "tp1u7r46zkgcmvel59tqa9352k5rycl985ywqnjp7",
-              "fee_amount": "75"
+              "fee_amount": "75",
+              "entity_detail": {
+                "name": "Cat Auxiliary Fund Source",
+                "description": "Extra fees for extra cute cats"
+              }
             }
           ],
           "entity_detail": {
@@ -405,7 +409,11 @@ asset definition.
           "fee_destinations": [
             {
               "address": "tp1s735l5tmh7sngyvvn6rf4l7e9e9qq8uz93z9ky",
-              "fee_amount": "500000000"
+              "fee_amount": "500000000",
+              "entity_detail": {
+                "name": "Car Detailer",
+                "descriptions": "Details the cars and charges a fee to do it"
+              }
             },
             {
               "address": "tp1k5m8lkshpupuf44p02r4mwgjdawd2kta4n9ry0",
@@ -463,7 +471,11 @@ ensures that after the update, all scope specification addresses contained in as
           "fee_destinations": [
             {
               "address": "tp1s735l5tmh7sngyvvn6rf4l7e9e9qq8uz93z9ky",
-              "fee_amount": "20000"
+              "fee_amount": "20000",
+              "entity_detail": {
+                "name": "Car Theft Prevention Services",
+                "description": "Installs loud alarms in the cars to make sure if people steal them, everyone knows"
+              }
             }
           ],
           "entity_detail": {
@@ -551,7 +563,12 @@ parameter, or the request will be rejected.
       "fee_destinations": [
         {
           "address": "tp1lmp2qmntl090whuftym0wthzwjc8xv0v79cu6l",
-          "fee_amount": "250"
+          "fee_amount": "250",
+          "entity_detail": {
+            "name": "Conductor Fee Collector",
+            "description": "Train conductors need to eat, too!",
+            "home_url": "www.trainconductorshomesite.gov/how-do-conductors-make-money-from-the-blockchain"
+          }
         }
       ],
       "entity_detail": {
@@ -741,11 +758,19 @@ OR
         "fee_destinations": [
           {
             "address": "tp126lrty2c0h78mdtjyzzf7mtsge427trccq8lta",
-            "fee_amount": "1000"
+            "fee_amount": "1000",
+            "entity_detail": {
+              "name": "Totally Not a Dog Collecting Fees",
+              "description": "Bark! Bark! Uh... I mean, I'm an administrator of the website and totally a human",
+              "home_url": "https://www.totallynotadog.truth/i-am-not-a-dog"
+            }
           },
           {
             "address": "tp1gkg4a8zrtadlz5c5u56fuhcf5gq3xy4v8pgaef",
-            "fee_amount": "234"
+            "fee_amount": "234",
+            "entity_detail": {
+              "description": "All the fields for entity detail are optional, so this one only provides a description!"
+            }
           }
         ],
         "entity_detail": {
@@ -795,7 +820,10 @@ No parameters are used for the `QueryAssetDefinitions` route.
             "fee_destinations": [
               {
                 "address": "tp126lrty2c0h78mdtjyzzf7mtsge427trccq8lta",
-                "fee_amount": "250"
+                "fee_amount": "250",
+                "entity_detail": {
+                  "description": "All the ferret charges go to this account"
+                }
               }
             ],
             "entity_detail": {

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -5,13 +5,13 @@ use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
 use asset_classification_smart_contract::core::msg::{ExecuteMsg, InitMsg, MigrateMsg, QueryMsg};
 use asset_classification_smart_contract::core::types::asset_definition::{
-    AssetDefinition, AssetDefinitionInput,
+    AssetDefinitionInputV2, AssetDefinitionV2,
 };
 use asset_classification_smart_contract::core::types::asset_identifier::AssetIdentifier;
 use asset_classification_smart_contract::core::types::asset_qualifier::AssetQualifier;
 use asset_classification_smart_contract::core::types::asset_scope_attribute::AssetScopeAttribute;
 use asset_classification_smart_contract::core::types::serialized_enum::SerializedEnum;
-use asset_classification_smart_contract::core::types::verifier_detail::VerifierDetail;
+use asset_classification_smart_contract::core::types::verifier_detail::VerifierDetailV2;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -24,9 +24,9 @@ fn main() {
     export_schema(&schema_for!(QueryMsg), &out_dir);
     export_schema(&schema_for!(MigrateMsg), &out_dir);
     export_schema(&schema_for!(AssetScopeAttribute), &out_dir);
-    export_schema(&schema_for!(AssetDefinition), &out_dir);
-    export_schema(&schema_for!(AssetDefinitionInput), &out_dir);
-    export_schema(&schema_for!(VerifierDetail), &out_dir);
+    export_schema(&schema_for!(AssetDefinitionV2), &out_dir);
+    export_schema(&schema_for!(AssetDefinitionInputV2), &out_dir);
+    export_schema(&schema_for!(VerifierDetailV2), &out_dir);
     export_schema(&schema_for!(AssetIdentifier), &out_dir);
     export_schema(&schema_for!(AssetQualifier), &out_dir);
     export_schema(&schema_for!(SerializedEnum), &out_dir);

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -10,6 +10,7 @@ use asset_classification_smart_contract::core::types::asset_definition::{
 use asset_classification_smart_contract::core::types::asset_identifier::AssetIdentifier;
 use asset_classification_smart_contract::core::types::asset_qualifier::AssetQualifier;
 use asset_classification_smart_contract::core::types::asset_scope_attribute::AssetScopeAttribute;
+use asset_classification_smart_contract::core::types::fee_destination::FeeDestinationV2;
 use asset_classification_smart_contract::core::types::serialized_enum::SerializedEnum;
 use asset_classification_smart_contract::core::types::verifier_detail::VerifierDetailV2;
 
@@ -27,6 +28,7 @@ fn main() {
     export_schema(&schema_for!(AssetDefinitionV2), &out_dir);
     export_schema(&schema_for!(AssetDefinitionInputV2), &out_dir);
     export_schema(&schema_for!(VerifierDetailV2), &out_dir);
+    export_schema(&schema_for!(FeeDestinationV2), &out_dir);
     export_schema(&schema_for!(AssetIdentifier), &out_dir);
     export_schema(&schema_for!(AssetQualifier), &out_dir);
     export_schema(&schema_for!(SerializedEnum), &out_dir);

--- a/schema/asset_definition_input_v2.json
+++ b/schema/asset_definition_input_v2.json
@@ -102,7 +102,7 @@
           ]
         },
         "fee_amount": {
-          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
+          "description": "The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always sum with the other fee destinations to be less than or at most equal to the total onboarding cost.",
           "allOf": [
             {
               "$ref": "#/definitions/Uint128"
@@ -138,7 +138,6 @@
       "type": "object",
       "required": [
         "address",
-        "fee_amount",
         "fee_destinations",
         "onboarding_cost",
         "onboarding_denom"
@@ -159,16 +158,8 @@
             }
           ]
         },
-        "fee_amount": {
-          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Uint128"
-            }
-          ]
-        },
         "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "description": "Each account that should receive fees when onboarding a new scope to the contract. All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to an amount less than or equal to the [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost). Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/FeeDestinationV2"

--- a/schema/asset_definition_input_v2.json
+++ b/schema/asset_definition_input_v2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "AssetDefinitionInput",
+  "title": "AssetDefinitionInputV2",
   "description": "Allows the user to optionally specify the enabled flag on an asset definition, versus forcing it to be added manually on every request, when it will likely always be specified as `true`.",
   "type": "object",
   "required": [
@@ -39,15 +39,11 @@
       "description": "Individual verifier definitions.  There can be many verifiers for a single asset type.  Each value must have a unique `address` property or requests to add will be rejected.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/VerifierDetail"
+        "$ref": "#/definitions/VerifierDetailV2"
       }
     }
   },
   "definitions": {
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
-    },
     "EntityDetail": {
       "description": "Various fields describing an entity, which could be an organization, account, etc.",
       "type": "object",
@@ -82,23 +78,23 @@
         }
       }
     },
-    "FeeDestination": {
+    "FeeDestinationV2": {
       "description": "Defines an external account designated as a recipient of funds during the verification process.",
       "type": "object",
       "required": [
         "address",
-        "fee_percent"
+        "fee_amount"
       ],
       "properties": {
         "address": {
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
-        "fee_percent": {
-          "description": "The amount to be distributed to this account from the designated total [fee_percent](super::verifier_detail::VerifierDetail::fee_percent) of the containing [VerifierDetail](super::verifier_detail::VerifierDetail).  This number should always be between 0 and 1, and indicate a percentage.  Ex: 0.5 indicates 50%. For instance, if the fee total is 100nhash and the verifier detail's fee percent is .5 (50%) and the destination's fee percent is 1 (100%), then that fee destination account would receive 50nhash during the transaction, which is 100% of the 50% designated to fee accounts.",
+        "fee_amount": {
+          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
         }
@@ -126,13 +122,13 @@
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     },
-    "VerifierDetail": {
-      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinition](super::asset_definition::AssetDefinition).",
+    "VerifierDetailV2": {
+      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).",
       "type": "object",
       "required": [
         "address",
+        "fee_amount",
         "fee_destinations",
-        "fee_percent",
         "onboarding_cost",
         "onboarding_denom"
       ],
@@ -152,20 +148,20 @@
             }
           ]
         },
-        "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_percent](self::VerifierDetail::fee_percent). All of these destinations' individual [fee_percent](super::fee_destination::FeeDestination::fee_percent) properties should sum to 1.  Less amounts will cause this verifier detail to be considered invalid and rejected in requests that include it.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/FeeDestination"
-          }
-        },
-        "fee_percent": {
-          "description": "The percent amount taken from the total [onboarding_cost](self::VerifierDetail::onboarding_cost) to send to the underlying [FeeDestinations](super::fee_destination::FeeDestination). This should be a number from 0 to 1, representing a percentage (ex: 0.35 = 35%).",
+        "fee_amount": {
+          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
+        },
+        "fee_destinations": {
+          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FeeDestinationV2"
+          }
         },
         "onboarding_cost": {
           "description": "The total amount charged to use the onboarding process this this verifier.",

--- a/schema/asset_definition_input_v2.json
+++ b/schema/asset_definition_input_v2.json
@@ -90,6 +90,17 @@
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
+        "entity_detail": {
+          "description": "An optional set of fields that define the fee destination, including its name and home URL location.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntityDetail"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "fee_amount": {
           "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [

--- a/schema/asset_definition_v2.json
+++ b/schema/asset_definition_v2.json
@@ -77,6 +77,17 @@
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
+        "entity_detail": {
+          "description": "An optional set of fields that define the fee destination, including its name and home URL location.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntityDetail"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "fee_amount": {
           "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [

--- a/schema/asset_definition_v2.json
+++ b/schema/asset_definition_v2.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "AssetDefinition",
+  "title": "AssetDefinitionV2",
   "description": "Defines a specific asset type associated with the contract.  Allows its specified type to be onboarded and verified.",
   "type": "object",
   "required": [
@@ -26,15 +26,11 @@
       "description": "Individual verifier definitions.  There can be many verifiers for a single asset type.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/VerifierDetail"
+        "$ref": "#/definitions/VerifierDetailV2"
       }
     }
   },
   "definitions": {
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
-    },
     "EntityDetail": {
       "description": "Various fields describing an entity, which could be an organization, account, etc.",
       "type": "object",
@@ -69,23 +65,23 @@
         }
       }
     },
-    "FeeDestination": {
+    "FeeDestinationV2": {
       "description": "Defines an external account designated as a recipient of funds during the verification process.",
       "type": "object",
       "required": [
         "address",
-        "fee_percent"
+        "fee_amount"
       ],
       "properties": {
         "address": {
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
-        "fee_percent": {
-          "description": "The amount to be distributed to this account from the designated total [fee_percent](super::verifier_detail::VerifierDetail::fee_percent) of the containing [VerifierDetail](super::verifier_detail::VerifierDetail).  This number should always be between 0 and 1, and indicate a percentage.  Ex: 0.5 indicates 50%. For instance, if the fee total is 100nhash and the verifier detail's fee percent is .5 (50%) and the destination's fee percent is 1 (100%), then that fee destination account would receive 50nhash during the transaction, which is 100% of the 50% designated to fee accounts.",
+        "fee_amount": {
+          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
         }
@@ -95,13 +91,13 @@
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     },
-    "VerifierDetail": {
-      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinition](super::asset_definition::AssetDefinition).",
+    "VerifierDetailV2": {
+      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).",
       "type": "object",
       "required": [
         "address",
+        "fee_amount",
         "fee_destinations",
-        "fee_percent",
         "onboarding_cost",
         "onboarding_denom"
       ],
@@ -121,20 +117,20 @@
             }
           ]
         },
-        "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_percent](self::VerifierDetail::fee_percent). All of these destinations' individual [fee_percent](super::fee_destination::FeeDestination::fee_percent) properties should sum to 1.  Less amounts will cause this verifier detail to be considered invalid and rejected in requests that include it.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/FeeDestination"
-          }
-        },
-        "fee_percent": {
-          "description": "The percent amount taken from the total [onboarding_cost](self::VerifierDetail::onboarding_cost) to send to the underlying [FeeDestinations](super::fee_destination::FeeDestination). This should be a number from 0 to 1, representing a percentage (ex: 0.35 = 35%).",
+        "fee_amount": {
+          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
+        },
+        "fee_destinations": {
+          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FeeDestinationV2"
+          }
         },
         "onboarding_cost": {
           "description": "The total amount charged to use the onboarding process this this verifier.",

--- a/schema/asset_definition_v2.json
+++ b/schema/asset_definition_v2.json
@@ -89,7 +89,7 @@
           ]
         },
         "fee_amount": {
-          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
+          "description": "The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always sum with the other fee destinations to be less than or at most equal to the total onboarding cost.",
           "allOf": [
             {
               "$ref": "#/definitions/Uint128"
@@ -107,7 +107,6 @@
       "type": "object",
       "required": [
         "address",
-        "fee_amount",
         "fee_destinations",
         "onboarding_cost",
         "onboarding_denom"
@@ -128,16 +127,8 @@
             }
           ]
         },
-        "fee_amount": {
-          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Uint128"
-            }
-          ]
-        },
         "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "description": "Each account that should receive fees when onboarding a new scope to the contract. All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to an amount less than or equal to the [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost). Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/FeeDestinationV2"

--- a/schema/asset_qualifier.json
+++ b/schema/asset_qualifier.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AssetQualifier",
-  "description": "An enum containing different identifiers that can be used to fetch an [AssetDefinition](super::asset_definition::AssetDefinition).",
+  "description": "An enum containing different identifiers that can be used to fetch an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).",
   "anyOf": [
     {
       "description": "The unique name for an asset type.  Ex: heloc, payable, etc.",

--- a/schema/asset_scope_attribute.json
+++ b/schema/asset_scope_attribute.json
@@ -43,7 +43,7 @@
       "description": "When the onboarding process runs, the verifier detail currently in contract storage for the verifier address chosen by the requestor is added to the scope attribute.  This ensures that if the verifier values change due to an external update, the original fee structure will be honored for the onboarding task placed originally.",
       "anyOf": [
         {
-          "$ref": "#/definitions/VerifierDetail"
+          "$ref": "#/definitions/VerifierDetailV2"
         },
         {
           "type": "null"
@@ -169,10 +169,6 @@
         }
       }
     },
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
-    },
     "EntityDetail": {
       "description": "Various fields describing an entity, which could be an organization, account, etc.",
       "type": "object",
@@ -207,23 +203,23 @@
         }
       }
     },
-    "FeeDestination": {
+    "FeeDestinationV2": {
       "description": "Defines an external account designated as a recipient of funds during the verification process.",
       "type": "object",
       "required": [
         "address",
-        "fee_percent"
+        "fee_amount"
       ],
       "properties": {
         "address": {
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
-        "fee_percent": {
-          "description": "The amount to be distributed to this account from the designated total [fee_percent](super::verifier_detail::VerifierDetail::fee_percent) of the containing [VerifierDetail](super::verifier_detail::VerifierDetail).  This number should always be between 0 and 1, and indicate a percentage.  Ex: 0.5 indicates 50%. For instance, if the fee total is 100nhash and the verifier detail's fee percent is .5 (50%) and the destination's fee percent is 1 (100%), then that fee destination account would receive 50nhash during the transaction, which is 100% of the 50% designated to fee accounts.",
+        "fee_amount": {
+          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
         }
@@ -233,13 +229,13 @@
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     },
-    "VerifierDetail": {
-      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinition](super::asset_definition::AssetDefinition).",
+    "VerifierDetailV2": {
+      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).",
       "type": "object",
       "required": [
         "address",
+        "fee_amount",
         "fee_destinations",
-        "fee_percent",
         "onboarding_cost",
         "onboarding_denom"
       ],
@@ -259,20 +255,20 @@
             }
           ]
         },
-        "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_percent](self::VerifierDetail::fee_percent). All of these destinations' individual [fee_percent](super::fee_destination::FeeDestination::fee_percent) properties should sum to 1.  Less amounts will cause this verifier detail to be considered invalid and rejected in requests that include it.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/FeeDestination"
-          }
-        },
-        "fee_percent": {
-          "description": "The percent amount taken from the total [onboarding_cost](self::VerifierDetail::onboarding_cost) to send to the underlying [FeeDestinations](super::fee_destination::FeeDestination). This should be a number from 0 to 1, representing a percentage (ex: 0.35 = 35%).",
+        "fee_amount": {
+          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
+        },
+        "fee_destinations": {
+          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FeeDestinationV2"
+          }
         },
         "onboarding_cost": {
           "description": "The total amount charged to use the onboarding process this this verifier.",

--- a/schema/asset_scope_attribute.json
+++ b/schema/asset_scope_attribute.json
@@ -215,6 +215,17 @@
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
+        "entity_detail": {
+          "description": "An optional set of fields that define the fee destination, including its name and home URL location.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntityDetail"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "fee_amount": {
           "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [

--- a/schema/asset_scope_attribute.json
+++ b/schema/asset_scope_attribute.json
@@ -227,7 +227,7 @@
           ]
         },
         "fee_amount": {
-          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
+          "description": "The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always sum with the other fee destinations to be less than or at most equal to the total onboarding cost.",
           "allOf": [
             {
               "$ref": "#/definitions/Uint128"
@@ -245,7 +245,6 @@
       "type": "object",
       "required": [
         "address",
-        "fee_amount",
         "fee_destinations",
         "onboarding_cost",
         "onboarding_denom"
@@ -266,16 +265,8 @@
             }
           ]
         },
-        "fee_amount": {
-          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Uint128"
-            }
-          ]
-        },
         "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "description": "Each account that should receive fees when onboarding a new scope to the contract. All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to an amount less than or equal to the [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost). Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/FeeDestinationV2"

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -423,7 +423,7 @@
           ]
         },
         "fee_amount": {
-          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
+          "description": "The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always sum with the other fee destinations to be less than or at most equal to the total onboarding cost.",
           "allOf": [
             {
               "$ref": "#/definitions/Uint128"
@@ -459,7 +459,6 @@
       "type": "object",
       "required": [
         "address",
-        "fee_amount",
         "fee_destinations",
         "onboarding_cost",
         "onboarding_denom"
@@ -480,16 +479,8 @@
             }
           ]
         },
-        "fee_amount": {
-          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Uint128"
-            }
-          ]
-        },
         "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "description": "Each account that should receive fees when onboarding a new scope to the contract. All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to an amount less than or equal to the [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost). Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/FeeDestinationV2"

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -411,6 +411,17 @@
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
+        "entity_detail": {
+          "description": "An optional set of fields that define the fee destination, including its name and home URL location.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntityDetail"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "fee_amount": {
           "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -4,7 +4,7 @@
   "description": "Defines all routes in which the contract can be executed.  These are all handled directly in the [contract file](crate::contract::execute).",
   "anyOf": [
     {
-      "description": "This route is the primary interaction point for most consumers.  It consumes an asset uuid or scope address, the type of asset corresponding to that scope (heloc, mortgage, payable, etc), and, if all checks pass, attaches an attribute to the provided scope that stages the scope for verification of authenticity by the specified verifier in the request.  The attribute is attached based on the [base_contract_name](self::InitMsg::base_contract_name) specified in the contract, combined with the specified asset type in the request.  Ex: if [base_contract_name](self::InitMsg::base_contract_name) is \"asset\" and the asset type is \"myasset\", the attribute would be assigned under the name of \"myasset.asset\".  All available asset types are queryable, and stored in the contract as [AssetDefinition](super::types::asset_definition::AssetDefinition) values.  After onboarding is completed, an [AssetScopeAttribute](super::types::asset_scope_attribute::AssetScopeAttribute) will be stored on the scope with an [AssetOnboardingStatus](super::types::asset_onboarding_status::AssetOnboardingStatus) of [Pending](super::types::asset_onboarding_status::AssetOnboardingStatus::Pending), indicating that the asset has been onboarded to the contract but is awaiting verification.",
+      "description": "This route is the primary interaction point for most consumers.  It consumes an asset uuid or scope address, the type of asset corresponding to that scope (heloc, mortgage, payable, etc), and, if all checks pass, attaches an attribute to the provided scope that stages the scope for verification of authenticity by the specified verifier in the request.  The attribute is attached based on the [base_contract_name](self::InitMsg::base_contract_name) specified in the contract, combined with the specified asset type in the request.  Ex: if [base_contract_name](self::InitMsg::base_contract_name) is \"asset\" and the asset type is \"myasset\", the attribute would be assigned under the name of \"myasset.asset\".  All available asset types are queryable, and stored in the contract as [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) values.  After onboarding is completed, an [AssetScopeAttribute](super::types::asset_scope_attribute::AssetScopeAttribute) will be stored on the scope with an [AssetOnboardingStatus](super::types::asset_onboarding_status::AssetOnboardingStatus) of [Pending](super::types::asset_onboarding_status::AssetOnboardingStatus::Pending), indicating that the asset has been onboarded to the contract but is awaiting verification.",
       "type": "object",
       "required": [
         "onboard_asset"
@@ -29,7 +29,7 @@
               }
             },
             "asset_type": {
-              "description": "A name that must directly match one of the contract's internal [AssetDefinition](super::types::asset_definition::AssetDefinition) names.  Any request with a specified type not matching an asset definition will be rejected outright.",
+              "description": "A name that must directly match one of the contract's internal [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) names.  Any request with a specified type not matching an asset definition will be rejected outright.",
               "type": "string"
             },
             "identifier": {
@@ -41,7 +41,7 @@
               ]
             },
             "verifier_address": {
-              "description": "The bech32 address of a Verifier Account associated with the targeted [AssetDefinition](super::types::asset_definition::AssetDefinition), within its nested vector of [VerifierDetails](super::types::verifier_detail::VerifierDetail).",
+              "description": "The bech32 address of a Verifier Account associated with the targeted [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2), within its nested vector of [VerifierDetailV2s](super::types::verifier_detail::VerifierDetailV2).",
               "type": "string"
             }
           }
@@ -98,7 +98,7 @@
       "additionalProperties": false
     },
     {
-      "description": "__This route is only accessible to the contract's admin address.__  This route allows a new [AssetDefinition](super::types::asset_definition::AssetDefinition) value to be added to the contract's internal storage.  These asset definitions dictate which asset types are allowed to be onboarded, as well as which verifiers are tied to each asset type.  Each added asset definition must be unique in two criteria: * Its [asset_type](super::types::asset_definition::AssetDefinition::asset_type) value must not yet be registered in a different asset definition. * Its [scope_spec_address](super::types::asset_definition::AssetDefinition::scope_spec_address) (entered as a [ScopeSpecIdentifier](super::types::scope_spec_identifier::ScopeSpecIdentifier)) must also be unique across asset definitions. Additionally, all added asset definitions must refer to an existing [Provenance Metadata Scope Specification](https://docs.provenance.io/modules/metadata-module#scope-specification).",
+      "description": "__This route is only accessible to the contract's admin address.__  This route allows a new [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) value to be added to the contract's internal storage.  These asset definitions dictate which asset types are allowed to be onboarded, as well as which verifiers are tied to each asset type.  Each added asset definition must be unique in two criteria: * Its [asset_type](super::types::asset_definition::AssetDefinition::asset_type) value must not yet be registered in a different asset definition. * Its [scope_spec_address](super::types::asset_definition::AssetDefinition::scope_spec_address) (entered as a [ScopeSpecIdentifier](super::types::scope_spec_identifier::ScopeSpecIdentifier)) must also be unique across asset definitions. Additionally, all added asset definitions must refer to an existing [Provenance Metadata Scope Specification](https://docs.provenance.io/modules/metadata-module#scope-specification).",
       "type": "object",
       "required": [
         "add_asset_definition"
@@ -111,10 +111,10 @@
           ],
           "properties": {
             "asset_definition": {
-              "description": "An asset definition input value defining all of the new [AssetDefinition](super::types::asset_definition::AssetDefinition)'s values.  The execution route converts the incoming value to an asset definition.",
+              "description": "An asset definition input value defining all of the new [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)'s values.  The execution route converts the incoming value to an asset definition.",
               "allOf": [
                 {
-                  "$ref": "#/definitions/AssetDefinitionInput"
+                  "$ref": "#/definitions/AssetDefinitionInputV2"
                 }
               ]
             }
@@ -124,7 +124,7 @@
       "additionalProperties": false
     },
     {
-      "description": "__This route is only accessible to the contract's admin address.__ This route allows an existing [AssetDefinition](super::types::asset_definition::AssetDefinition) value to be updated.  It works by matching the input's [asset_type](super::types::asset_definition::AssetDefinition::asset_type) to an existing asset definition and overwriting the existing values.  If no asset definition exists for the given type, the request will be rejected.  Contract validation ensures that after the update, all scope specification addresses contained in asset definitions remain unique, as well.",
+      "description": "__This route is only accessible to the contract's admin address.__ This route allows an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) value to be updated.  It works by matching the input's [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type) to an existing asset definition and overwriting the existing values.  If no asset definition exists for the given type, the request will be rejected.  Contract validation ensures that after the update, all scope specification addresses contained in asset definitions remain unique, as well.",
       "type": "object",
       "required": [
         "update_asset_definition"
@@ -137,10 +137,10 @@
           ],
           "properties": {
             "asset_definition": {
-              "description": "An asset definition input value defining all of the updated [AssetDefinition](super::types::asset_definition::AssetDefinition)'s values.  The execution route converts the incoming value to an asset definition.",
+              "description": "An asset definition input value defining all of the updated [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)'s values.  The execution route converts the incoming value to an asset definition.",
               "allOf": [
                 {
-                  "$ref": "#/definitions/AssetDefinitionInput"
+                  "$ref": "#/definitions/AssetDefinitionInputV2"
                 }
               ]
             }
@@ -150,7 +150,7 @@
       "additionalProperties": false
     },
     {
-      "description": "__This route is only accessible to the contract's admin address.__ This route toggles an existing [AssetDefinition](super::types::asset_definition::AssetDefinition) from enabled to disabled, or disabled to enabled.  When disabled, an asset definition will no longer allow new assets to be onboarded to the contract.  Existing assets already onboarded to the contract and in pending status will still be allowed to be verified, but new values will be rejected.  This same functionality could be achieved with an invocation of the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) route but swapping the [enabled](super::types::asset_definition::AssetDefinition::enabled) value on the `asset_definition` parameter, but this route is significantly simpler and prevents accidental data mutation due to it not requiring the entirety of the definition's values.",
+      "description": "__This route is only accessible to the contract's admin address.__ This route toggles an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) from enabled to disabled, or disabled to enabled.  When disabled, an asset definition will no longer allow new assets to be onboarded to the contract.  Existing assets already onboarded to the contract and in pending status will still be allowed to be verified, but new values will be rejected.  This same functionality could be achieved with an invocation of the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) route but swapping the [enabled](super::types::asset_definition::AssetDefinitionV2::enabled) value on the `asset_definition` parameter, but this route is significantly simpler and prevents accidental data mutation due to it not requiring the entirety of the definition's values.",
       "type": "object",
       "required": [
         "toggle_asset_definition"
@@ -164,11 +164,11 @@
           ],
           "properties": {
             "asset_type": {
-              "description": "The type of asset for which the definition's [enabled](super::types::asset_definition::AssetDefinition::enabled) value will be toggled.  As the asset type value on each asset definition is guaranteed to be unique, this key is all that is needed to find the target definition.",
+              "description": "The type of asset for which the definition's [enabled](super::types::asset_definition::AssetDefinitionV2::enabled) value will be toggled.  As the asset type value on each asset definition is guaranteed to be unique, this key is all that is needed to find the target definition.",
               "type": "string"
             },
             "expected_result": {
-              "description": "The value of [enabled](super::types::asset_definition::AssetDefinition::enabled) after the toggle takes place.  This value is required to ensure that multiple toggles executed in succession (either by accident or by various unrelated callers) will only be honored if the asset definition is in the intended state during the execution of the route.",
+              "description": "The value of [enabled](super::types::asset_definition::AssetDefinitionV2::enabled) after the toggle takes place.  This value is required to ensure that multiple toggles executed in succession (either by accident or by various unrelated callers) will only be honored if the asset definition is in the intended state during the execution of the route.",
               "type": "boolean"
             }
           }
@@ -177,7 +177,7 @@
       "additionalProperties": false
     },
     {
-      "description": "__This route is only accessible to the contract's admin address.__ This route adds a new [VerifierDetail](super::types::verifier_detail::VerifierDetail) to an existing [AssetDefinition](super::types::asset_definition::AssetDefinition).  This route is intended to register new verifiers without the bulky requirements of the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) execution route.  This route will reject verifiers added with addresses that match any other verifiers on the target asset definition.",
+      "description": "__This route is only accessible to the contract's admin address.__ This route adds a new [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).  This route is intended to register new verifiers without the bulky requirements of the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) execution route.  This route will reject verifiers added with addresses that match any other verifiers on the target asset definition.",
       "type": "object",
       "required": [
         "add_asset_verifier"
@@ -191,14 +191,14 @@
           ],
           "properties": {
             "asset_type": {
-              "description": "The type of asset for which the new [VerifierDetail](super::types::verifier_detail::VerifierDetail) will be added. This must refer to an existing [AssetDefinition](super::types::asset_definition::AssetDefinition)'s [asset_type](super::types::asset_definition::AssetDefinition::asset_type) value, or the request will be rejected.",
+              "description": "The type of asset for which the new [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) will be added. This must refer to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)'s [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type) value, or the request will be rejected.",
               "type": "string"
             },
             "verifier": {
-              "description": "The new verifier detail to be added to the asset definition, with all of its required values.  No verifiers within the existing asset definition must have the same [address](super::types::verifier_detail::VerifierDetail::address) value of this parameter, or the request will be rejected.",
+              "description": "The new verifier detail to be added to the asset definition, with all of its required values.  No verifiers within the existing asset definition must have the same [address](super::types::verifier_detail::VerifierDetailV2::address) value of this parameter, or the request will be rejected.",
               "allOf": [
                 {
-                  "$ref": "#/definitions/VerifierDetail"
+                  "$ref": "#/definitions/VerifierDetailV2"
                 }
               ]
             }
@@ -208,7 +208,7 @@
       "additionalProperties": false
     },
     {
-      "description": "__This route is only accessible to the contract's admin address.__ This route updates an existing [VerifierDetail](super::types::verifier_detail::VerifierDetail) in an existing [AssetDefinition](super::types::asset_definition::AssetDefinition).  This route is intended to be used when the values of a single verifier detail need to change, but not the entire asset definition.  The request will be rejected if the referenced asset definition is not present within the contract, or if a verifier does not exist within the asset definition that matches the address of the provided verifier data.",
+      "description": "__This route is only accessible to the contract's admin address.__ This route updates an existing [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) in an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).  This route is intended to be used when the values of a single verifier detail need to change, but not the entire asset definition.  The request will be rejected if the referenced asset definition is not present within the contract, or if a verifier does not exist within the asset definition that matches the address of the provided verifier data.",
       "type": "object",
       "required": [
         "update_asset_verifier"
@@ -222,14 +222,14 @@
           ],
           "properties": {
             "asset_type": {
-              "description": "The type of asset for which the [VerifierDetail](super::types::verifier_detail::VerifierDetail) will be updated. This must refer to an existing [AssetDefinition](super::types::asset_definition::AssetDefinition)'s [asset_type](super::types::asset_definition::AssetDefinition::asset_type) value, or the request will be rejected.",
+              "description": "The type of asset for which the [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) will be updated. This must refer to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)'s [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type) value, or the request will be rejected.",
               "type": "string"
             },
             "verifier": {
-              "description": "The updated verifier detail to be modified in the asset definition. An existing verifier detail within the target asset definition must have a matching [address](super::types::verifier_detail::VerifierDetail::address) value, or the request will be rejected.",
+              "description": "The updated verifier detail to be modified in the asset definition. An existing verifier detail within the target asset definition must have a matching [address](super::types::verifier_detail::VerifierDetailV2::address) value, or the request will be rejected.",
               "allOf": [
                 {
-                  "$ref": "#/definitions/VerifierDetail"
+                  "$ref": "#/definitions/VerifierDetailV2"
                 }
               ]
             }
@@ -321,7 +321,7 @@
         }
       }
     },
-    "AssetDefinitionInput": {
+    "AssetDefinitionInputV2": {
       "description": "Allows the user to optionally specify the enabled flag on an asset definition, versus forcing it to be added manually on every request, when it will likely always be specified as `true`.",
       "type": "object",
       "required": [
@@ -360,14 +360,10 @@
           "description": "Individual verifier definitions.  There can be many verifiers for a single asset type.  Each value must have a unique `address` property or requests to add will be rejected.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/VerifierDetail"
+            "$ref": "#/definitions/VerifierDetailV2"
           }
         }
       }
-    },
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
     },
     "EntityDetail": {
       "description": "Various fields describing an entity, which could be an organization, account, etc.",
@@ -403,23 +399,23 @@
         }
       }
     },
-    "FeeDestination": {
+    "FeeDestinationV2": {
       "description": "Defines an external account designated as a recipient of funds during the verification process.",
       "type": "object",
       "required": [
         "address",
-        "fee_percent"
+        "fee_amount"
       ],
       "properties": {
         "address": {
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
-        "fee_percent": {
-          "description": "The amount to be distributed to this account from the designated total [fee_percent](super::verifier_detail::VerifierDetail::fee_percent) of the containing [VerifierDetail](super::verifier_detail::VerifierDetail).  This number should always be between 0 and 1, and indicate a percentage.  Ex: 0.5 indicates 50%. For instance, if the fee total is 100nhash and the verifier detail's fee percent is .5 (50%) and the destination's fee percent is 1 (100%), then that fee destination account would receive 50nhash during the transaction, which is 100% of the 50% designated to fee accounts.",
+        "fee_amount": {
+          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
         }
@@ -447,13 +443,13 @@
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     },
-    "VerifierDetail": {
-      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinition](super::asset_definition::AssetDefinition).",
+    "VerifierDetailV2": {
+      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).",
       "type": "object",
       "required": [
         "address",
+        "fee_amount",
         "fee_destinations",
-        "fee_percent",
         "onboarding_cost",
         "onboarding_denom"
       ],
@@ -473,20 +469,20 @@
             }
           ]
         },
-        "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_percent](self::VerifierDetail::fee_percent). All of these destinations' individual [fee_percent](super::fee_destination::FeeDestination::fee_percent) properties should sum to 1.  Less amounts will cause this verifier detail to be considered invalid and rejected in requests that include it.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/FeeDestination"
-          }
-        },
-        "fee_percent": {
-          "description": "The percent amount taken from the total [onboarding_cost](self::VerifierDetail::onboarding_cost) to send to the underlying [FeeDestinations](super::fee_destination::FeeDestination). This should be a number from 0 to 1, representing a percentage (ex: 0.35 = 35%).",
+        "fee_amount": {
+          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
+        },
+        "fee_destinations": {
+          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FeeDestinationV2"
+          }
         },
         "onboarding_cost": {
           "description": "The total amount charged to use the onboarding process this this verifier.",

--- a/schema/fee_destination_v2.json
+++ b/schema/fee_destination_v2.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "FeeDestinationV2",
+  "description": "Defines an external account designated as a recipient of funds during the verification process.",
+  "type": "object",
+  "required": [
+    "address",
+    "fee_amount"
+  ],
+  "properties": {
+    "address": {
+      "description": "The Provenance Blockchain bech32 address belonging to the account.",
+      "type": "string"
+    },
+    "entity_detail": {
+      "description": "An optional set of fields that define the fee destination, including its name and home URL location.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/EntityDetail"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "fee_amount": {
+      "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Uint128"
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "EntityDetail": {
+      "description": "Various fields describing an entity, which could be an organization, account, etc.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "description": "A short description of the entity's purpose.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "home_url": {
+          "description": "A web link that can send observers to the organization that the entity belongs to.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "description": "A short name describing the entity.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_url": {
+          "description": "A web link that can send observers to the source code of the entity for increased transparency.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "Uint128": {
+      "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
+      "type": "string"
+    }
+  }
+}

--- a/schema/fee_destination_v2.json
+++ b/schema/fee_destination_v2.json
@@ -24,7 +24,7 @@
       ]
     },
     "fee_amount": {
-      "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
+      "description": "The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always sum with the other fee destinations to be less than or at most equal to the total onboarding cost.",
       "allOf": [
         {
           "$ref": "#/definitions/Uint128"

--- a/schema/init_msg.json
+++ b/schema/init_msg.json
@@ -123,6 +123,17 @@
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
+        "entity_detail": {
+          "description": "An optional set of fields that define the fee destination, including its name and home URL location.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntityDetail"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "fee_amount": {
           "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [

--- a/schema/init_msg.json
+++ b/schema/init_msg.json
@@ -10,18 +10,18 @@
   ],
   "properties": {
     "asset_definitions": {
-      "description": "All the initial [AssetDefinitionV2s](super::types::access_definition::AccessDefinitionV2) for the contract.  This can be left empty and new definitions can be added later using the [Add Asset Definition](crate::execute::add_asset_definition) functionality.",
+      "description": "All the initial [AssetDefinitionV2s](super::types::asset_definition::AssetDefinitionV2) for the contract.  This can be left empty and new definitions can be added later using the [Add Asset Definition](crate::execute::add_asset_definition) functionality.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/AssetDefinitionInputV2"
       }
     },
     "base_contract_name": {
-      "description": "The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitionV2s](super::types::access_definition::AccessDefinitionV2) will use this value as their parent name.",
+      "description": "The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitionV2s](super::types::asset_definition::AssetDefinitionV2) will use this value as their parent name.",
       "type": "string"
     },
     "bind_base_name": {
-      "description": "If `true`, the contract will automatically try to bind its [base_contract_name](self::InitMsg::base_contract_name) during the instantiation process to itself.  No action will be taken if the value is `false`, but the base name will still be recorded in the contract's [state](super::state::StateV2) and be used for child names for [AssetDefinitions](super::types::access_definition::AccessDefinition).",
+      "description": "If `true`, the contract will automatically try to bind its [base_contract_name](self::InitMsg::base_contract_name) during the instantiation process to itself.  No action will be taken if the value is `false`, but the base name will still be recorded in the contract's [state](super::state::StateV2) and be used for child names for [AssetDefinitions](super::types::asset_definition::AssetDefinitionV2).",
       "type": "boolean"
     },
     "is_test": {
@@ -135,7 +135,7 @@
           ]
         },
         "fee_amount": {
-          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
+          "description": "The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always sum with the other fee destinations to be less than or at most equal to the total onboarding cost.",
           "allOf": [
             {
               "$ref": "#/definitions/Uint128"
@@ -171,7 +171,6 @@
       "type": "object",
       "required": [
         "address",
-        "fee_amount",
         "fee_destinations",
         "onboarding_cost",
         "onboarding_denom"
@@ -192,16 +191,8 @@
             }
           ]
         },
-        "fee_amount": {
-          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
-          "allOf": [
-            {
-              "$ref": "#/definitions/Uint128"
-            }
-          ]
-        },
         "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "description": "Each account that should receive fees when onboarding a new scope to the contract. All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to an amount less than or equal to the [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost). Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/FeeDestinationV2"

--- a/schema/init_msg.json
+++ b/schema/init_msg.json
@@ -13,7 +13,7 @@
       "description": "All the initial [AssetDefinitions](super::types::access_definition::AccessDefinition) for the contract.  This can be left empty and new definitions can be added later using the [Add Asset Definition](crate::execute::add_asset_definition) functionality.",
       "type": "array",
       "items": {
-        "$ref": "#/definitions/AssetDefinitionInput"
+        "$ref": "#/definitions/AssetDefinitionInputV2"
       }
     },
     "base_contract_name": {
@@ -33,7 +33,7 @@
     }
   },
   "definitions": {
-    "AssetDefinitionInput": {
+    "AssetDefinitionInputV2": {
       "description": "Allows the user to optionally specify the enabled flag on an asset definition, versus forcing it to be added manually on every request, when it will likely always be specified as `true`.",
       "type": "object",
       "required": [
@@ -72,14 +72,10 @@
           "description": "Individual verifier definitions.  There can be many verifiers for a single asset type.  Each value must have a unique `address` property or requests to add will be rejected.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/VerifierDetail"
+            "$ref": "#/definitions/VerifierDetailV2"
           }
         }
       }
-    },
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
     },
     "EntityDetail": {
       "description": "Various fields describing an entity, which could be an organization, account, etc.",
@@ -115,23 +111,23 @@
         }
       }
     },
-    "FeeDestination": {
+    "FeeDestinationV2": {
       "description": "Defines an external account designated as a recipient of funds during the verification process.",
       "type": "object",
       "required": [
         "address",
-        "fee_percent"
+        "fee_amount"
       ],
       "properties": {
         "address": {
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
-        "fee_percent": {
-          "description": "The amount to be distributed to this account from the designated total [fee_percent](super::verifier_detail::VerifierDetail::fee_percent) of the containing [VerifierDetail](super::verifier_detail::VerifierDetail).  This number should always be between 0 and 1, and indicate a percentage.  Ex: 0.5 indicates 50%. For instance, if the fee total is 100nhash and the verifier detail's fee percent is .5 (50%) and the destination's fee percent is 1 (100%), then that fee destination account would receive 50nhash during the transaction, which is 100% of the 50% designated to fee accounts.",
+        "fee_amount": {
+          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
         }
@@ -159,13 +155,13 @@
       "description": "A thin wrapper around u128 that is using strings for JSON encoding/decoding, such that the full u128 range can be used for clients that convert JSON numbers to floats, like JavaScript and jq.\n\n# Examples\n\nUse `from` to create instances of this and `u128` to get the value out:\n\n``` # use cosmwasm_std::Uint128; let a = Uint128::from(123u128); assert_eq!(a.u128(), 123);\n\nlet b = Uint128::from(42u64); assert_eq!(b.u128(), 42);\n\nlet c = Uint128::from(70u32); assert_eq!(c.u128(), 70); ```",
       "type": "string"
     },
-    "VerifierDetail": {
-      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinition](super::asset_definition::AssetDefinition).",
+    "VerifierDetailV2": {
+      "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).",
       "type": "object",
       "required": [
         "address",
+        "fee_amount",
         "fee_destinations",
-        "fee_percent",
         "onboarding_cost",
         "onboarding_denom"
       ],
@@ -185,20 +181,20 @@
             }
           ]
         },
-        "fee_destinations": {
-          "description": "Each account that should receive the amount designated in the [fee_percent](self::VerifierDetail::fee_percent). All of these destinations' individual [fee_percent](super::fee_destination::FeeDestination::fee_percent) properties should sum to 1.  Less amounts will cause this verifier detail to be considered invalid and rejected in requests that include it.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/FeeDestination"
-          }
-        },
-        "fee_percent": {
-          "description": "The percent amount taken from the total [onboarding_cost](self::VerifierDetail::onboarding_cost) to send to the underlying [FeeDestinations](super::fee_destination::FeeDestination). This should be a number from 0 to 1, representing a percentage (ex: 0.35 = 35%).",
+        "fee_amount": {
+          "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
+        },
+        "fee_destinations": {
+          "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/FeeDestinationV2"
+          }
         },
         "onboarding_cost": {
           "description": "The total amount charged to use the onboarding process this this verifier.",

--- a/schema/init_msg.json
+++ b/schema/init_msg.json
@@ -10,14 +10,14 @@
   ],
   "properties": {
     "asset_definitions": {
-      "description": "All the initial [AssetDefinitions](super::types::access_definition::AccessDefinition) for the contract.  This can be left empty and new definitions can be added later using the [Add Asset Definition](crate::execute::add_asset_definition) functionality.",
+      "description": "All the initial [AssetDefinitionV2s](super::types::access_definition::AccessDefinitionV2) for the contract.  This can be left empty and new definitions can be added later using the [Add Asset Definition](crate::execute::add_asset_definition) functionality.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/AssetDefinitionInputV2"
       }
     },
     "base_contract_name": {
-      "description": "The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitions](super::types::access_definition::AccessDefinition) will use this value as their parent name.",
+      "description": "The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitionV2s](super::types::access_definition::AccessDefinitionV2) will use this value as their parent name.",
       "type": "string"
     },
     "bind_base_name": {

--- a/schema/migrate_msg.json
+++ b/schema/migrate_msg.json
@@ -28,6 +28,30 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "migrate_to_asset_definition_v2"
+      ],
+      "properties": {
+        "migrate_to_asset_definition_v2": {
+          "type": "object",
+          "properties": {
+            "options": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/MigrationOptions"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -4,7 +4,7 @@
   "description": "Defines all routes in which the contract can be queried.  These are all handled directly in the [contract file](crate::contract::query).",
   "anyOf": [
     {
-      "description": "This route can be used to retrieve a specific [AssetDefinition](super::types::asset_definition::AssetDefinition) from the contract's internal storage for inspection of its verifies and other properties.  If the requested value is not found, a null response will be returned.",
+      "description": "This route can be used to retrieve a specific [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) from the contract's internal storage for inspection of its verifies and other properties.  If the requested value is not found, a null response will be returned.",
       "type": "object",
       "required": [
         "query_asset_definition"
@@ -30,7 +30,7 @@
       "additionalProperties": false
     },
     {
-      "description": "This route can be used to retrieve all [AssetDefinitions](super::types::asset_definition::AssetDefinition) stored in the contract.  This response payload can be quite large if many complex definitions are stored, so it should only used in circumstances where all asset definitions need to be inspected or displayed.  The query asset definition route is much more efficient.",
+      "description": "This route can be used to retrieve all [AssetDefinitionV2s](super::types::asset_definition::AssetDefinitionV2) stored in the contract.  This response payload can be quite large if many complex definitions are stored, so it should only used in circumstances where all asset definitions need to be inspected or displayed.  The query asset definition route is much more efficient.",
       "type": "object",
       "required": [
         "query_asset_definitions"

--- a/schema/verifier_detail_v2.json
+++ b/schema/verifier_detail_v2.json
@@ -1,12 +1,12 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "VerifierDetail",
-  "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinition](super::asset_definition::AssetDefinition).",
+  "title": "VerifierDetailV2",
+  "description": "Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).",
   "type": "object",
   "required": [
     "address",
+    "fee_amount",
     "fee_destinations",
-    "fee_percent",
     "onboarding_cost",
     "onboarding_denom"
   ],
@@ -26,20 +26,20 @@
         }
       ]
     },
-    "fee_destinations": {
-      "description": "Each account that should receive the amount designated in the [fee_percent](self::VerifierDetail::fee_percent). All of these destinations' individual [fee_percent](super::fee_destination::FeeDestination::fee_percent) properties should sum to 1.  Less amounts will cause this verifier detail to be considered invalid and rejected in requests that include it.",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/FeeDestination"
-      }
-    },
-    "fee_percent": {
-      "description": "The percent amount taken from the total [onboarding_cost](self::VerifierDetail::onboarding_cost) to send to the underlying [FeeDestinations](super::fee_destination::FeeDestination). This should be a number from 0 to 1, representing a percentage (ex: 0.35 = 35%).",
+    "fee_amount": {
+      "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
       "allOf": [
         {
-          "$ref": "#/definitions/Decimal"
+          "$ref": "#/definitions/Uint128"
         }
       ]
+    },
+    "fee_destinations": {
+      "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FeeDestinationV2"
+      }
     },
     "onboarding_cost": {
       "description": "The total amount charged to use the onboarding process this this verifier.",
@@ -55,10 +55,6 @@
     }
   },
   "definitions": {
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
-    },
     "EntityDetail": {
       "description": "Various fields describing an entity, which could be an organization, account, etc.",
       "type": "object",
@@ -93,23 +89,23 @@
         }
       }
     },
-    "FeeDestination": {
+    "FeeDestinationV2": {
       "description": "Defines an external account designated as a recipient of funds during the verification process.",
       "type": "object",
       "required": [
         "address",
-        "fee_percent"
+        "fee_amount"
       ],
       "properties": {
         "address": {
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
-        "fee_percent": {
-          "description": "The amount to be distributed to this account from the designated total [fee_percent](super::verifier_detail::VerifierDetail::fee_percent) of the containing [VerifierDetail](super::verifier_detail::VerifierDetail).  This number should always be between 0 and 1, and indicate a percentage.  Ex: 0.5 indicates 50%. For instance, if the fee total is 100nhash and the verifier detail's fee percent is .5 (50%) and the destination's fee percent is 1 (100%), then that fee destination account would receive 50nhash during the transaction, which is 100% of the 50% designated to fee accounts.",
+        "fee_amount": {
+          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [
             {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             }
           ]
         }

--- a/schema/verifier_detail_v2.json
+++ b/schema/verifier_detail_v2.json
@@ -5,7 +5,6 @@
   "type": "object",
   "required": [
     "address",
-    "fee_amount",
     "fee_destinations",
     "onboarding_cost",
     "onboarding_denom"
@@ -26,16 +25,8 @@
         }
       ]
     },
-    "fee_amount": {
-      "description": "The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost) to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost) itself.",
-      "allOf": [
-        {
-          "$ref": "#/definitions/Uint128"
-        }
-      ]
-    },
     "fee_destinations": {
-      "description": "Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount). All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
+      "description": "Each account that should receive fees when onboarding a new scope to the contract. All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties should sum to an amount less than or equal to the [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost). Amounts not precisely equal in sum will cause this verifier detail to be considered invalid and rejected in requests that include it.",
       "type": "array",
       "items": {
         "$ref": "#/definitions/FeeDestinationV2"
@@ -113,7 +104,7 @@
           ]
         },
         "fee_amount": {
-          "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
+          "description": "The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always sum with the other fee destinations to be less than or at most equal to the total onboarding cost.",
           "allOf": [
             {
               "$ref": "#/definitions/Uint128"

--- a/schema/verifier_detail_v2.json
+++ b/schema/verifier_detail_v2.json
@@ -101,6 +101,17 @@
           "description": "The Provenance Blockchain bech32 address belonging to the account.",
           "type": "string"
         },
+        "entity_detail": {
+          "description": "An optional set of fields that define the fee destination, including its name and home URL location.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntityDetail"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "fee_amount": {
           "description": "The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should always be less than or equal to the fee amount, and all fee destinations on a verifier detail should sum to the specified fee amount.",
           "allOf": [

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -10,6 +10,7 @@ use crate::execute::update_asset_verifier::{update_asset_verifier, UpdateAssetVe
 use crate::execute::verify_asset::{verify_asset, VerifyAssetV1};
 use crate::instantiate::init_contract::init_contract;
 use crate::migrate::migrate_contract::migrate_contract;
+use crate::migrate::migrate_to_asset_definition_v2::migrate_to_asset_definition_v2;
 use crate::query::query_asset_definition::query_asset_definition;
 use crate::query::query_asset_definitions::query_asset_definitions;
 use crate::query::query_asset_scope_attribute::query_asset_scope_attribute;
@@ -152,5 +153,8 @@ pub fn execute(deps: DepsMutC, env: Env, info: MessageInfo, msg: ExecuteMsg) -> 
 pub fn migrate(deps: DepsMutC, _env: Env, msg: MigrateMsg) -> EntryPointResponse {
     match msg {
         MigrateMsg::ContractUpgrade { options } => migrate_contract(deps, options),
+        MigrateMsg::MigrateToAssetDefinitionV2 { options } => {
+            migrate_to_asset_definition_v2(deps, options)
+        }
     }
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -73,8 +73,8 @@ pub enum ContractError {
         verifier_address: String,
     },
 
-    /// This error is encountered when an asset is attempted to be onboarded as a specific [asset_type](super::types::asset_definition::AssetDefinition::asset_type),
-    /// but the [AssetDefinition](super::types::asset_definition::AssetDefinition) for that type
+    /// This error is encountered when an asset is attempted to be onboarded as a specific [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type),
+    /// but the [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) for that type
     /// has a different Provenance Blockchain Scope Specification bech32 address listed in the
     /// contract's internal storage.  This is to prevent scopes from being onboarded as a specific
     /// type unless they meet the correct specification listed on the blockchain.
@@ -86,24 +86,24 @@ pub enum ContractError {
         scope_address: String,
         /// The bech32 scope specification address listed on the scope provided during onboarding.
         scope_spec_address: String,
-        /// The bech32 scope specification address listed in the [AssetDefinition](super::types::asset_definition::AssetDefinition)
+        /// The bech32 scope specification address listed in the [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)
         /// stored for the given asset type.
         expected_scope_spec_address: String,
     },
 
-    /// This error indicates that an asset was attempted to be onboarded with an [asset_type](super::types::asset_definition::AssetDefinition::asset_type)
-    /// linked to an [AssetDefinition](super::types::asset_definition::AssetDefinition) that is
-    /// currently not [enabled](super::types::asset_definition::AssetDefinition::enabled)]
+    /// This error indicates that an asset was attempted to be onboarded with an [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type)
+    /// linked to an [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) that is
+    /// currently not [enabled](super::types::asset_definition::AssetDefinitionV2::enabled)]
     #[error("Asset type {asset_type} is currently disabled")]
     AssetTypeDisabled {
         /// The type of asset that is currently disabled.
         asset_type: String,
     },
 
-    /// Denotes that an existing [VerifierDetail](super::types::verifier_detail::VerifierDetail)
-    /// has the same [address](super::types::verifier_detail::VerifierDetail::address) property
-    /// as the provided [VerifierDetail](super::types::verifier_detail::VerifierDetail) to be
-    /// added to an [AssetDefinition](crate::core::types::asset_definition::AssetDefinition).
+    /// Denotes that an existing [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2)
+    /// has the same [address](super::types::verifier_detail::VerifierDetailV2::address) property
+    /// as the provided [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) to be
+    /// added to an [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2).
     #[error("duplicate/existing verifier address provided as input")]
     DuplicateVerifierProvided,
 
@@ -184,9 +184,9 @@ pub enum ContractError {
     },
 
     /// An error that occurs when a lookup is attempted for a contract resource but the resource
-    /// does not exist.  For instance, when an [AssetDefinition](super::types::asset_definition::AssetDefinition)
-    /// does not contain a [VerifierDetail](super::types::verifier_detail::VerifierDetail) with a
-    /// specified bech32 [address](super::types::verifier_detail::VerifierDetail::address), this
+    /// does not exist.  For instance, when an [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)
+    /// does not contain a [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) with a
+    /// specified bech32 [address](super::types::verifier_detail::VerifierDetailV2::address), this
     /// error will occur.
     #[error("Resource not found: {explanation}")]
     NotFound {
@@ -264,14 +264,14 @@ pub enum ContractError {
         asset_type: String,
     },
 
-    /// This error can occur when a target [VerifierDetail](super::types::verifier_detail::VerifierDetail)
-    /// does not exist in an [AssetDefinition](super::types::asset_definition::AssetDefinition) during
+    /// This error can occur when a target [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2)
+    /// does not exist in an [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) during
     /// the onboarding process.
     #[error("Unsupported verifier [{verifier_address}] for asset type [{asset_type}]")]
     UnsupportedVerifier {
         /// The bech32 address of the target verifier.
         verifier_address: String,
-        /// The [asset_type](super::types::asset_definition::AssetDefinition::asset_type) selected
+        /// The [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type) selected
         /// during onboarding.
         asset_type: String,
     },

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -10,7 +10,7 @@ use super::types::access_route::AccessRoute;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct InitMsg {
-    /// The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitions](super::types::access_definition::AccessDefinition)
+    /// The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitionV2s](super::types::access_definition::AccessDefinitionV2)
     /// will use this value as their parent name.
     pub base_contract_name: String,
     /// If `true`, the contract will automatically try to bind its [base_contract_name](self::InitMsg::base_contract_name)
@@ -18,7 +18,7 @@ pub struct InitMsg {
     /// but the base name will still be recorded in the contract's [state](super::state::StateV2)
     /// and be used for child names for [AssetDefinitions](super::types::access_definition::AccessDefinition).
     pub bind_base_name: bool,
-    /// All the initial [AssetDefinitions](super::types::access_definition::AccessDefinition) for the
+    /// All the initial [AssetDefinitionV2s](super::types::access_definition::AccessDefinitionV2) for the
     /// contract.  This can be left empty and new definitions can be added later using the [Add Asset Definition](crate::execute::add_asset_definition)
     /// functionality.
     pub asset_definitions: Vec<AssetDefinitionInputV2>,
@@ -34,7 +34,7 @@ pub struct InitMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum QueryMsg {
-    /// This route can be used to retrieve a specific [AssetDefinition](super::types::asset_definition::AssetDefinition) from the contract's
+    /// This route can be used to retrieve a specific [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) from the contract's
     /// internal storage for inspection of its verifies and other properties.  If the requested value is not found, a null
     /// response will be returned.
     QueryAssetDefinition {
@@ -42,7 +42,7 @@ pub enum QueryMsg {
         /// [SerializedEnum](super::types::serialized_enum::SerializedEnum).
         qualifier: SerializedEnum,
     },
-    /// This route can be used to retrieve all [AssetDefinitions](super::types::asset_definition::AssetDefinition) stored in the contract.  This response payload can be quite
+    /// This route can be used to retrieve all [AssetDefinitionV2s](super::types::asset_definition::AssetDefinitionV2) stored in the contract.  This response payload can be quite
     /// large if many complex definitions are stored, so it should only used in circumstances where all asset definitions need
     /// to be inspected or displayed.  The query asset definition route is much more efficient.
     QueryAssetDefinitions {},

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -10,15 +10,15 @@ use super::types::access_route::AccessRoute;
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct InitMsg {
-    /// The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitionV2s](super::types::access_definition::AccessDefinitionV2)
+    /// The root name from which all asset names branch.  All sub-names specified in the [AssetDefinitionV2s](super::types::asset_definition::AssetDefinitionV2)
     /// will use this value as their parent name.
     pub base_contract_name: String,
     /// If `true`, the contract will automatically try to bind its [base_contract_name](self::InitMsg::base_contract_name)
     /// during the instantiation process to itself.  No action will be taken if the value is `false`,
     /// but the base name will still be recorded in the contract's [state](super::state::StateV2)
-    /// and be used for child names for [AssetDefinitions](super::types::access_definition::AccessDefinition).
+    /// and be used for child names for [AssetDefinitions](super::types::asset_definition::AssetDefinitionV2).
     pub bind_base_name: bool,
-    /// All the initial [AssetDefinitionV2s](super::types::access_definition::AccessDefinitionV2) for the
+    /// All the initial [AssetDefinitionV2s](super::types::asset_definition::AssetDefinitionV2) for the
     /// contract.  This can be left empty and new definitions can be added later using the [Add Asset Definition](crate::execute::add_asset_definition)
     /// functionality.
     pub asset_definitions: Vec<AssetDefinitionInputV2>,

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -1,11 +1,10 @@
+use crate::core::types::asset_definition::AssetDefinitionInputV2;
 use crate::core::types::serialized_enum::SerializedEnum;
+use crate::core::types::verifier_detail::VerifierDetailV2;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::types::{
-    access_route::AccessRoute, asset_definition::AssetDefinitionInput,
-    verifier_detail::VerifierDetail,
-};
+use super::types::access_route::AccessRoute;
 
 /// The struct used to instantiate the contract.  Utilized in the core [contract file](crate::contract::instantiate).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -22,7 +21,7 @@ pub struct InitMsg {
     /// All the initial [AssetDefinitions](super::types::access_definition::AccessDefinition) for the
     /// contract.  This can be left empty and new definitions can be added later using the [Add Asset Definition](crate::execute::add_asset_definition)
     /// functionality.
-    pub asset_definitions: Vec<AssetDefinitionInput>,
+    pub asset_definitions: Vec<AssetDefinitionInputV2>,
     /// A boolean value allowing for less restrictions to be placed on certain functionalities
     /// across the contract's execution processes.  Notably, this disables a check during the
     /// onboarding process to determine if onboarded scopes include underlying record values.  This
@@ -77,7 +76,7 @@ pub enum ExecuteMsg {
     /// provided scope that stages the scope for verification of authenticity by the specified verifier in the request.  The
     /// attribute is attached based on the [base_contract_name](self::InitMsg::base_contract_name) specified in the contract, combined with the specified asset type
     /// in the request.  Ex: if [base_contract_name](self::InitMsg::base_contract_name) is "asset" and the asset type is "myasset", the attribute would be assigned
-    /// under the name of "myasset.asset".  All available asset types are queryable, and stored in the contract as [AssetDefinition](super::types::asset_definition::AssetDefinition)
+    /// under the name of "myasset.asset".  All available asset types are queryable, and stored in the contract as [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)
     /// values.  After onboarding is completed, an [AssetScopeAttribute](super::types::asset_scope_attribute::AssetScopeAttribute) will be
     /// stored on the scope with an [AssetOnboardingStatus](super::types::asset_onboarding_status::AssetOnboardingStatus)
     /// of [Pending](super::types::asset_onboarding_status::AssetOnboardingStatus::Pending),
@@ -86,11 +85,11 @@ pub enum ExecuteMsg {
         /// Expects an [AssetIdentifier](super::types::asset_identifier::AssetIdentifier)-compatible
         /// [SerializedEnum](super::types::serialized_enum::SerializedEnum).
         identifier: SerializedEnum,
-        /// A name that must directly match one of the contract's internal [AssetDefinition](super::types::asset_definition::AssetDefinition)
+        /// A name that must directly match one of the contract's internal [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)
         /// names.  Any request with a specified type not matching an asset definition will be rejected outright.
         asset_type: String,
-        /// The bech32 address of a Verifier Account associated with the targeted [AssetDefinition](super::types::asset_definition::AssetDefinition),
-        /// within its nested vector of [VerifierDetails](super::types::verifier_detail::VerifierDetail).
+        /// The bech32 address of a Verifier Account associated with the targeted [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2),
+        /// within its nested vector of [VerifierDetailV2s](super::types::verifier_detail::VerifierDetailV2).
         verifier_address: String,
         /// An optional parameter that allows the specification of a location to get the underlying asset data
         /// for the specified scope.  The [AccessRoute](super::types::access_route::AccessRoute) struct is very generic in its composition
@@ -131,7 +130,7 @@ pub enum ExecuteMsg {
         /// interaction.
         access_routes: Option<Vec<AccessRoute>>,
     },
-    /// __This route is only accessible to the contract's admin address.__  This route allows a new [AssetDefinition](super::types::asset_definition::AssetDefinition)
+    /// __This route is only accessible to the contract's admin address.__  This route allows a new [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)
     /// value to be added to the contract's internal storage.  These asset definitions dictate which asset types are allowed to
     /// be onboarded, as well as which verifiers are tied to each asset type.  Each added asset definition must be unique in
     /// two criteria:
@@ -140,63 +139,63 @@ pub enum ExecuteMsg {
     /// must also be unique across asset definitions.
     /// Additionally, all added asset definitions must refer to an existing [Provenance Metadata Scope Specification](https://docs.provenance.io/modules/metadata-module#scope-specification).
     AddAssetDefinition {
-        /// An asset definition input value defining all of the new [AssetDefinition](super::types::asset_definition::AssetDefinition)'s
+        /// An asset definition input value defining all of the new [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)'s
         /// values.  The execution route converts the incoming value to an asset definition.
-        asset_definition: AssetDefinitionInput,
+        asset_definition: AssetDefinitionInputV2,
     },
-    /// __This route is only accessible to the contract's admin address.__ This route allows an existing [AssetDefinition](super::types::asset_definition::AssetDefinition)
-    /// value to be updated.  It works by matching the input's [asset_type](super::types::asset_definition::AssetDefinition::asset_type) to an existing asset definition and overwriting the
+    /// __This route is only accessible to the contract's admin address.__ This route allows an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)
+    /// value to be updated.  It works by matching the input's [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type) to an existing asset definition and overwriting the
     /// existing values.  If no asset definition exists for the given type, the request will be rejected.  Contract validation
     /// ensures that after the update, all scope specification addresses contained in asset definitions remain unique, as well.
     UpdateAssetDefinition {
-        /// An asset definition input value defining all of the updated [AssetDefinition](super::types::asset_definition::AssetDefinition)'s
+        /// An asset definition input value defining all of the updated [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)'s
         /// values.  The execution route converts the incoming value to an asset definition.
-        asset_definition: AssetDefinitionInput,
+        asset_definition: AssetDefinitionInputV2,
     },
-    /// __This route is only accessible to the contract's admin address.__ This route toggles an existing [AssetDefinition](super::types::asset_definition::AssetDefinition)
+    /// __This route is only accessible to the contract's admin address.__ This route toggles an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)
     /// from enabled to disabled, or disabled to enabled.  When disabled, an asset definition will no longer allow new assets to
     /// be onboarded to the contract.  Existing assets already onboarded to the contract and in pending status will still be
     /// allowed to be verified, but new values will be rejected.  This same functionality could be achieved with an invocation of
-    /// the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) route but swapping the [enabled](super::types::asset_definition::AssetDefinition::enabled)
+    /// the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) route but swapping the [enabled](super::types::asset_definition::AssetDefinitionV2::enabled)
     /// value on the `asset_definition` parameter, but this route is significantly simpler and prevents
     /// accidental data mutation due to it not requiring the entirety of the definition's values.
     ToggleAssetDefinition {
-        /// The type of asset for which the definition's [enabled](super::types::asset_definition::AssetDefinition::enabled) value will be toggled.  As the asset type value
+        /// The type of asset for which the definition's [enabled](super::types::asset_definition::AssetDefinitionV2::enabled) value will be toggled.  As the asset type value
         /// on each asset definition is guaranteed to be unique, this key is all that is needed to find the target definition.
         asset_type: String,
-        /// The value of [enabled](super::types::asset_definition::AssetDefinition::enabled) after the toggle takes place.  This value is required to ensure that
+        /// The value of [enabled](super::types::asset_definition::AssetDefinitionV2::enabled) after the toggle takes place.  This value is required to ensure that
         /// multiple toggles executed in succession (either by accident or by various unrelated callers) will only be honored if
         /// the asset definition is in the intended state during the execution of the route.
         expected_result: bool,
     },
-    /// __This route is only accessible to the contract's admin address.__ This route adds a new [VerifierDetail](super::types::verifier_detail::VerifierDetail)
-    /// to an existing [AssetDefinition](super::types::asset_definition::AssetDefinition).  This route is intended to register new verifiers
+    /// __This route is only accessible to the contract's admin address.__ This route adds a new [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2)
+    /// to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).  This route is intended to register new verifiers
     /// without the bulky requirements of the [UpdateAssetDefinition](self::ExecuteMsg::UpdateAssetDefinition) execution route.  This route will reject verifiers added
     /// with addresses that match any other verifiers on the target asset definition.
     AddAssetVerifier {
-        /// The type of asset for which the new [VerifierDetail](super::types::verifier_detail::VerifierDetail) will be added.
-        /// This must refer to an existing [AssetDefinition](super::types::asset_definition::AssetDefinition)'s [asset_type](super::types::asset_definition::AssetDefinition::asset_type)
+        /// The type of asset for which the new [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) will be added.
+        /// This must refer to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)'s [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type)
         /// value, or the request will be rejected.
         asset_type: String,
         /// The new verifier detail to be added to the asset definition, with all of its required
-        /// values.  No verifiers within the existing asset definition must have the same [address](super::types::verifier_detail::VerifierDetail::address) value of this
+        /// values.  No verifiers within the existing asset definition must have the same [address](super::types::verifier_detail::VerifierDetailV2::address) value of this
         /// parameter, or the request will be rejected.
-        verifier: VerifierDetail,
+        verifier: VerifierDetailV2,
     },
-    /// __This route is only accessible to the contract's admin address.__ This route updates an existing [VerifierDetail](super::types::verifier_detail::VerifierDetail)
-    /// in an existing [AssetDefinition](super::types::asset_definition::AssetDefinition).  This route is intended to be used when the values
+    /// __This route is only accessible to the contract's admin address.__ This route updates an existing [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2)
+    /// in an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).  This route is intended to be used when the values
     /// of a single verifier detail need to change, but not the entire asset definition.  The request will be rejected if the
     /// referenced asset definition is not present within the contract, or if a verifier does not exist within the asset
     /// definition that matches the address of the provided verifier data.
     UpdateAssetVerifier {
-        /// The type of asset for which the [VerifierDetail](super::types::verifier_detail::VerifierDetail) will be updated. This
-        /// must refer to an existing [AssetDefinition](super::types::asset_definition::AssetDefinition)'s [asset_type](super::types::asset_definition::AssetDefinition::asset_type)
+        /// The type of asset for which the [VerifierDetailV2](super::types::verifier_detail::VerifierDetailV2) will be updated. This
+        /// must refer to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)'s [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type)
         /// value, or the request will be rejected.
         asset_type: String,
         /// The updated verifier detail to be modified in the asset definition. An existing verifier
-        /// detail within the target asset definition must have a matching [address](super::types::verifier_detail::VerifierDetail::address)
+        /// detail within the target asset definition must have a matching [address](super::types::verifier_detail::VerifierDetailV2::address)
         /// value, or the request will be rejected.
-        verifier: VerifierDetail,
+        verifier: VerifierDetailV2,
     },
     /// __This route is only accessible to the contract's admin address OR to the owner of the access routes being updated.__
     /// This route will swap all existing access routes for a specific owner for a specific scope to the provided values. These

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -239,6 +239,10 @@ pub enum MigrateMsg {
         /// upgrade.
         options: Option<MigrationOptions>,
     },
+    // TODO: Remove after removing AssetDefinitionV1
+    MigrateToAssetDefinitionV2 {
+        options: Option<MigrationOptions>,
+    },
 }
 
 /// Sub-level struct that defines optional changes that can occur during the migration process.

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -1,3 +1,4 @@
+use crate::core::types::asset_definition::{AssetDefinition, AssetDefinitionV2};
 use crate::{
     core::msg::InitMsg,
     util::{
@@ -11,7 +12,7 @@ use cw_storage_plus::{Index, IndexList, IndexedMap, UniqueIndex};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-use super::{error::ContractError, types::asset_definition::AssetDefinition};
+use super::error::ContractError;
 
 pub static STATE_V2_KEY: &[u8] = b"state_v2";
 pub static ASSET_META_KEY: &[u8] = b"asset_meta";
@@ -70,6 +71,7 @@ pub fn config_read_v2(storage: &dyn Storage) -> ReadonlySingleton<StateV2> {
     singleton_read(storage, STATE_V2_KEY)
 }
 
+// TODO: Delete after removing all uses of AssetDefinitionV1
 /// Boilerplate implementation of indexes for an IndexMap around state.
 /// This establishes a unique index on the scope spec address to ensure
 /// that saves cannot include duplicate scope specs.
@@ -86,6 +88,7 @@ impl<'a> IndexList<AssetDefinition> for AssetDefinitionIndexes<'a> {
     }
 }
 
+// TODO: Delete after removing all uses of AssetDefinitionV1
 /// The main entrypoint access for [AssetDefinition](super::types::asset_definition::AssetDefinition) state.
 /// Establishes an index map for all definitions, allowing the standard save(), load() and iterator
 /// functionality. Private access to ensure only helper functions below are used.
@@ -100,19 +103,49 @@ pub fn asset_definitions<'a>(
     IndexedMap::new("asset_definitions", indexes)
 }
 
+/// Boilerplate implementation of indexes for an IndexMap around state.
+/// This establishes a unique index on the scope spec address to ensure
+/// that saves cannot include duplicate scope specs.
+/// If it becomes a requirement in the future that we have duplicate scope specs,
+/// we will need to swap to a MultiIndex, and a lot of the lookups in the contract
+/// will fall apart.
+pub struct AssetDefinitionIndexesV2<'a> {
+    scope_spec: UniqueIndex<'a, String, AssetDefinitionV2>,
+}
+impl<'a> IndexList<AssetDefinitionV2> for AssetDefinitionIndexesV2<'a> {
+    fn get_indexes(&'_ self) -> Box<dyn Iterator<Item = &'_ dyn Index<AssetDefinitionV2>> + '_> {
+        let v: Vec<&dyn Index<AssetDefinitionV2>> = vec![&self.scope_spec];
+        Box::new(v.into_iter())
+    }
+}
+
+/// The main entrypoint access for [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) state.
+/// Establishes an index map for all definitions, allowing the standard save(), load() and iterator
+/// functionality. Private access to ensure only helper functions below are used.
+pub fn asset_definitions_v2<'a>(
+) -> IndexedMap<'a, &'a [u8], AssetDefinitionV2, AssetDefinitionIndexesV2<'a>> {
+    let indexes = AssetDefinitionIndexesV2 {
+        scope_spec: UniqueIndex::new(
+            |d: &AssetDefinitionV2| d.scope_spec_address.clone().to_lowercase(),
+            "asset_definitions_v2__scope_spec_address",
+        ),
+    };
+    IndexedMap::new("asset_definitions_v2", indexes)
+}
+
 /// Inserts a new asset definition into storage. If a value already exists, an error will be returned.
-/// Note: Asset definitions must contain a unique [asset_type](super::types::asset_definition::AssetDefinition::asset_type)
-/// value, as well as a unique [scope_spec_address](super::types::asset_definition::AssetDefinition::scope_spec_address).
+/// Note: Asset definitions must contain a unique [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type)
+/// value, as well as a unique [scope_spec_address](super::types::asset_definition::AssetDefinitionV2::scope_spec_address).
 /// Either unique constraint being violated will return an error.
 ///
 /// # Parameters
 ///
 /// * `storage` A mutable reference to the contract's internal storage.
-pub fn insert_asset_definition(
+pub fn insert_asset_definition_v2(
     storage: &mut dyn Storage,
-    definition: &AssetDefinition,
+    definition: &AssetDefinitionV2,
 ) -> AssetResult<()> {
-    let state = asset_definitions();
+    let state = asset_definitions_v2();
     let key = &definition.storage_key();
     if let Ok(existing_def) = state.load(storage, key) {
         ContractError::RecordAlreadyExists {
@@ -121,7 +154,7 @@ pub fn insert_asset_definition(
                 existing_def.asset_type, existing_def.scope_spec_address
             ),
         }
-        .to_err()
+            .to_err()
     } else {
         // At this point, we know there is no old data available, so we can safely call the replace function and
         // specify None for the old_data param.
@@ -132,7 +165,7 @@ pub fn insert_asset_definition(
 }
 
 /// Replaces an existing asset definition in state with the provided value.  If no value exists for
-/// the given definition, an error will be returned.  Note: IndexedMap (the type [asset_definitions](self::asset_definitions)
+/// the given definition, an error will be returned.  Note: IndexedMap (the type [asset_definitions_v2](self::asset_definitions_v2)
 /// function returns) provides a really nice update() function that allows two branches (one for
 /// success and one for failure to find) that seems ideal for this functionality, but it requires a
 /// non-reference version of the data to be used. This requires that the provided definition must be
@@ -141,13 +174,13 @@ pub fn insert_asset_definition(
 /// # Parameters
 ///
 /// * `storage` A mutable reference to the contract's internal storage.
-/// * `definition` The asset definition to replace by matching on its [asset_type](super::types::asset_definition::AssetDefinition::asset_type)
+/// * `definition` The asset definition to replace by matching on its [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type)
 /// property.
-pub fn replace_asset_definition(
+pub fn replace_asset_definition_v2(
     storage: &mut dyn Storage,
-    definition: &AssetDefinition,
+    definition: &AssetDefinitionV2,
 ) -> AssetResult<()> {
-    let state = asset_definitions();
+    let state = asset_definitions_v2();
     let key = &definition.storage_key();
     if let Ok(existing_def) = state.load(storage, key) {
         // The documentation for the save() function in IndexedMap recommends calling replace() directly after
@@ -177,13 +210,13 @@ pub fn replace_asset_definition(
 /// # Parameters
 ///
 /// * `storage` A reference to the contract's internal storage.
-/// * `asset_type` The unique name key [asset_type](super::types::asset_definition::AssetDefinition::asset_type)
+/// * `asset_type` The unique name key [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type)
 /// for the requested asset definition.
-pub fn may_load_asset_definition_by_type<S: Into<String>>(
+pub fn may_load_asset_definition_v2_by_type<S: Into<String>>(
     storage: &dyn Storage,
     asset_type: S,
-) -> AssetResult<Option<AssetDefinition>> {
-    asset_definitions()
+) -> AssetResult<Option<AssetDefinitionV2>> {
+    asset_definitions_v2()
         // Coerce to lowercase to match how stored values are keyed
         .may_load(storage, asset_type.into().to_lowercase().as_bytes())
         .map_err(ContractError::Std)
@@ -194,14 +227,14 @@ pub fn may_load_asset_definition_by_type<S: Into<String>>(
 /// # Parameters
 ///
 /// * `storage` A reference to the contract's internal storage.
-/// * `asset_type` The unique name key [asset_type](super::types::asset_definition::AssetDefinition::asset_type)
+/// * `asset_type` The unique name key [asset_type](super::types::asset_definition::AssetDefinitionV2::asset_type)
 /// for the requested asset definition.
-pub fn load_asset_definition_by_type<S: Into<String>>(
+pub fn load_asset_definition_v2_by_type<S: Into<String>>(
     storage: &dyn Storage,
     asset_type: S,
-) -> AssetResult<AssetDefinition> {
+) -> AssetResult<AssetDefinitionV2> {
     let asset_type = asset_type.into();
-    if let Some(asset_definition) = may_load_asset_definition_by_type(storage, &asset_type)? {
+    if let Some(asset_definition) = may_load_asset_definition_v2_by_type(storage, &asset_type)? {
         asset_definition.to_ok()
     } else {
         ContractError::RecordNotFound {
@@ -217,15 +250,15 @@ pub fn load_asset_definition_by_type<S: Into<String>>(
 /// # Parameters
 ///
 /// * `storage` A reference to the contract's internal storage.
-/// * `scope_spec_address` The unique address key [scope_spec_address](super::types::asset_definition::AssetDefinition::scope_spec_address)
+/// * `scope_spec_address` The unique address key [scope_spec_address](super::types::asset_definition::AssetDefinitionV2::scope_spec_address)
 /// for the requested asset definition.
-pub fn may_load_asset_definition_by_scope_spec<S: Into<String>>(
+pub fn may_load_asset_definition_v2_by_scope_spec<S: Into<String>>(
     storage: &dyn Storage,
     scope_spec_address: S,
-) -> AssetResult<Option<AssetDefinition>> {
+) -> AssetResult<Option<AssetDefinitionV2>> {
     // Coerce to lowercase to match how stored values are keyed
     let spec_addr = scope_spec_address.into().to_lowercase();
-    asset_definitions()
+    asset_definitions_v2()
         .idx
         .scope_spec
         .item(storage, spec_addr)
@@ -239,15 +272,15 @@ pub fn may_load_asset_definition_by_scope_spec<S: Into<String>>(
 /// # Parameters
 ///
 /// * `storage` A reference to the contract's internal storage.
-/// * `scope_spec_address` The unique address key [scope_spec_address](super::types::asset_definition::AssetDefinition::scope_spec_address)
+/// * `scope_spec_address` The unique address key [scope_spec_address](super::types::asset_definition::AssetDefinitionV2::scope_spec_address)
 /// for the requested asset definition.
-pub fn load_asset_definition_by_scope_spec<S: Into<String>>(
+pub fn load_asset_definition_v2_by_scope_spec<S: Into<String>>(
     storage: &dyn Storage,
     scope_spec_address: S,
-) -> AssetResult<AssetDefinition> {
+) -> AssetResult<AssetDefinitionV2> {
     let scope_spec_address = scope_spec_address.into();
     if let Some(asset_definition) =
-        may_load_asset_definition_by_scope_spec(storage, &scope_spec_address)?
+        may_load_asset_definition_v2_by_scope_spec(storage, &scope_spec_address)?
     {
         asset_definition.to_ok()
     } else {
@@ -265,23 +298,21 @@ pub fn load_asset_definition_by_scope_spec<S: Into<String>>(
 mod tests {
     use provwasm_mocks::mock_dependencies;
 
-    use crate::core::{
-        error::ContractError,
-        state::{
-            load_asset_definition_by_scope_spec, load_asset_definition_by_type,
-            may_load_asset_definition_by_scope_spec, may_load_asset_definition_by_type,
-        },
-        types::asset_definition::AssetDefinition,
+    use crate::core::error::ContractError;
+    use crate::core::state::{
+        insert_asset_definition_v2, load_asset_definition_v2_by_scope_spec,
+        load_asset_definition_v2_by_type, may_load_asset_definition_v2_by_scope_spec,
+        may_load_asset_definition_v2_by_type, replace_asset_definition_v2,
     };
-
-    use super::{insert_asset_definition, replace_asset_definition};
+    use crate::core::types::asset_definition::AssetDefinitionV2;
 
     #[test]
     fn test_insert_asset_definition() {
         let mut deps = mock_dependencies(&[]);
-        let def = AssetDefinition::new("heloc", "heloc-scope-spec", vec![]);
-        insert_asset_definition(deps.as_mut().storage, &def).expect("insert should work correctly");
-        let error = insert_asset_definition(deps.as_mut().storage, &def).unwrap_err();
+        let def = AssetDefinitionV2::new("heloc", "heloc-scope-spec", vec![]);
+        insert_asset_definition_v2(deps.as_mut().storage, &def)
+            .expect("insert should work correctly");
+        let error = insert_asset_definition_v2(deps.as_mut().storage, &def).unwrap_err();
         match error {
             ContractError::RecordAlreadyExists { explanation } => {
                 assert_eq!(
@@ -292,16 +323,18 @@ mod tests {
             }
             _ => panic!("unexpected error encountered: {:?}", error),
         }
-        let def_with_same_scope_spec = AssetDefinition::new("mortgage", "heloc-scope-spec", vec![]);
+        let def_with_same_scope_spec =
+            AssetDefinitionV2::new("mortgage", "heloc-scope-spec", vec![]);
         let scope_spec_key_violation_error =
-            insert_asset_definition(deps.as_mut().storage, &def_with_same_scope_spec).unwrap_err();
+            insert_asset_definition_v2(deps.as_mut().storage, &def_with_same_scope_spec)
+                .unwrap_err();
         assert!(
             matches!(scope_spec_key_violation_error, ContractError::Std(_)),
             "violating the scope spec unique key should result in an error, but got incorrect error: {:?}",
             scope_spec_key_violation_error,
         );
         let loaded_asset_definition =
-            load_asset_definition_by_type(deps.as_ref().storage, &def.asset_type)
+            load_asset_definition_v2_by_type(deps.as_ref().storage, &def.asset_type)
                 .expect("asset definition should load without error");
         assert_eq!(
             loaded_asset_definition, def,
@@ -312,8 +345,8 @@ mod tests {
     #[test]
     fn test_replace_asset_definition() {
         let mut deps = mock_dependencies(&[]);
-        let mut def = AssetDefinition::new("heloc", "heloc-scope-spec", vec![]);
-        let error = replace_asset_definition(deps.as_mut().storage, &def).unwrap_err();
+        let mut def = AssetDefinitionV2::new("heloc", "heloc-scope-spec", vec![]);
+        let error = replace_asset_definition_v2(deps.as_mut().storage, &def).unwrap_err();
         match error {
             ContractError::RecordNotFound { explanation } => {
                 assert_eq!(
@@ -323,12 +356,13 @@ mod tests {
             }
             _ => panic!("unexpected error encountered: {:?}", error),
         };
-        insert_asset_definition(deps.as_mut().storage, &def).expect("insert should work correctly");
+        insert_asset_definition_v2(deps.as_mut().storage, &def)
+            .expect("insert should work correctly");
         def.scope_spec_address = "new-spec-address".to_string();
-        replace_asset_definition(deps.as_mut().storage, &def)
+        replace_asset_definition_v2(deps.as_mut().storage, &def)
             .expect("update should work correctly");
         let loaded_asset_definition =
-            load_asset_definition_by_type(deps.as_ref().storage, &def.asset_type)
+            load_asset_definition_v2_by_type(deps.as_ref().storage, &def.asset_type)
                 .expect("asset definition should load without error");
         assert_eq!(
             loaded_asset_definition, def,
@@ -339,17 +373,17 @@ mod tests {
     #[test]
     fn test_may_load_asset_definition_by_type() {
         let mut deps = mock_dependencies(&[]);
-        let heloc = AssetDefinition::new("heloc", "heloc-scope-spec", vec![]);
-        insert_asset_definition(deps.as_mut().storage, &heloc)
+        let heloc = AssetDefinitionV2::new("heloc", "heloc-scope-spec", vec![]);
+        insert_asset_definition_v2(deps.as_mut().storage, &heloc)
             .expect("the heloc definition should insert without error");
         assert!(
-            may_load_asset_definition_by_type(deps.as_ref().storage, "not-heloc")
+            may_load_asset_definition_v2_by_type(deps.as_ref().storage, "not-heloc")
                 .expect("may load asset definition by type should execute without error")
                 .is_none(),
             "expected the missing asset definition to return an empty Option",
         );
         assert_eq!(
-            may_load_asset_definition_by_type(deps.as_ref().storage, &heloc.asset_type)
+            may_load_asset_definition_v2_by_type(deps.as_ref().storage, &heloc.asset_type)
             .expect("may load asset definition by type should execute without error")
             .expect("expected the asset definition loaded by a populated type to be present"),
             heloc,
@@ -360,17 +394,17 @@ mod tests {
     #[test]
     fn test_load_asset_definition_by_type() {
         let mut deps = mock_dependencies(&[]);
-        let heloc = AssetDefinition::new("heloc", "heloc-scope-spec", vec![]);
-        let mortgage = AssetDefinition::new("mortgage", "mortgage-scope-spec", vec![]);
-        insert_asset_definition(deps.as_mut().storage, &heloc)
+        let heloc = AssetDefinitionV2::new("heloc", "heloc-scope-spec", vec![]);
+        let mortgage = AssetDefinitionV2::new("mortgage", "mortgage-scope-spec", vec![]);
+        insert_asset_definition_v2(deps.as_mut().storage, &heloc)
             .expect("the heloc definition should insert appropriately");
-        insert_asset_definition(deps.as_mut().storage, &mortgage)
+        insert_asset_definition_v2(deps.as_mut().storage, &mortgage)
             .expect("the mortgage definition should insert appropriately");
         let heloc_from_storage =
-            load_asset_definition_by_type(deps.as_ref().storage, &heloc.asset_type)
+            load_asset_definition_v2_by_type(deps.as_ref().storage, &heloc.asset_type)
                 .expect("the heloc definition should load without error");
         let mortgage_from_storage =
-            load_asset_definition_by_type(deps.as_ref().storage, &mortgage.asset_type)
+            load_asset_definition_v2_by_type(deps.as_ref().storage, &mortgage.asset_type)
                 .expect("the mortgage definition should load without error");
         assert_eq!(
             heloc, heloc_from_storage,
@@ -385,17 +419,20 @@ mod tests {
     #[test]
     fn test_may_load_asset_definition_by_scope_spec_address() {
         let mut deps = mock_dependencies(&[]);
-        let heloc = AssetDefinition::new("heloc", "heloc-scope-spec", vec![]);
-        insert_asset_definition(deps.as_mut().storage, &heloc)
+        let heloc = AssetDefinitionV2::new("heloc", "heloc-scope-spec", vec![]);
+        insert_asset_definition_v2(deps.as_mut().storage, &heloc)
             .expect("the heloc definition should insert without error");
         assert!(
-            may_load_asset_definition_by_scope_spec(deps.as_ref().storage, "not-heloc-scope-spec")
-                .expect("may load asset definition by scope spec should execute without error")
-                .is_none(),
+            may_load_asset_definition_v2_by_scope_spec(
+                deps.as_ref().storage,
+                "not-heloc-scope-spec"
+            )
+            .expect("may load asset definition by scope spec should execute without error")
+            .is_none(),
             "expected the missing asset definition to return an empty Option",
         );
         assert_eq!(
-            may_load_asset_definition_by_scope_spec(deps.as_ref().storage, &heloc.scope_spec_address)
+            may_load_asset_definition_v2_by_scope_spec(deps.as_ref().storage, &heloc.scope_spec_address)
             .expect("may load asset definition by scope spec should execute without error")
             .expect("expected the asset definition loaded by a populated scope spec address to be present"),
             heloc,
@@ -406,16 +443,18 @@ mod tests {
     #[test]
     fn test_load_asset_definition_by_scope_spec() {
         let mut deps = mock_dependencies(&[]);
-        let heloc = AssetDefinition::new("heloc", "heloc-scope-spec", vec![]);
-        let mortgage = AssetDefinition::new("mortgage", "mortgage-scope-spec", vec![]);
-        insert_asset_definition(deps.as_mut().storage, &heloc)
+        let heloc = AssetDefinitionV2::new("heloc", "heloc-scope-spec", vec![]);
+        let mortgage = AssetDefinitionV2::new("mortgage", "mortgage-scope-spec", vec![]);
+        insert_asset_definition_v2(deps.as_mut().storage, &heloc)
             .expect("the heloc definition should insert appropriately");
-        insert_asset_definition(deps.as_mut().storage, &mortgage)
+        insert_asset_definition_v2(deps.as_mut().storage, &mortgage)
             .expect("the mortgage definition should insert appropriately");
-        let heloc_from_storage =
-            load_asset_definition_by_scope_spec(deps.as_ref().storage, &heloc.scope_spec_address)
-                .expect("the heloc definition should load without error");
-        let mortgage_from_storage = load_asset_definition_by_scope_spec(
+        let heloc_from_storage = load_asset_definition_v2_by_scope_spec(
+            deps.as_ref().storage,
+            &heloc.scope_spec_address,
+        )
+        .expect("the heloc definition should load without error");
+        let mortgage_from_storage = load_asset_definition_v2_by_scope_spec(
             deps.as_ref().storage,
             &mortgage.scope_spec_address,
         )

--- a/src/core/types/asset_definition.rs
+++ b/src/core/types/asset_definition.rs
@@ -370,11 +370,6 @@ mod tests {
             "nhash", verifier.onboarding_denom,
             "expected the verifier onboarding denom to be properly ported",
         );
-        assert_eq!(
-            0,
-            verifier.fee_amount.u128(),
-            "expected the verifier fee amount to be properly ported",
-        );
         assert!(
             verifier.fee_destinations.is_empty(),
             "expected no fee destinations to be ported",
@@ -431,11 +426,6 @@ mod tests {
         assert_eq!(
             "nhash", verifier.onboarding_denom,
             "expected the verifier onboarding denom to be properly ported",
-        );
-        assert_eq!(
-            75,
-            verifier.fee_amount.u128(),
-            "expected the verifier fee amount to be properly derived",
         );
         let fee_destination = assert_single_item(
             &verifier.fee_destinations,
@@ -506,11 +496,6 @@ mod tests {
         assert_eq!(
             "nhash", verifier.onboarding_denom,
             "expected the verifier onboarding denom to be properly ported",
-        );
-        assert_eq!(
-            200,
-            verifier.fee_amount.u128(),
-            "expected the verifier fee amount to be properly derived",
         );
         let fee_destination_1 = assert_single_item_by(
             &verifier.fee_destinations,
@@ -603,11 +588,6 @@ mod tests {
             "nhash", verifier_1.onboarding_denom,
             "expected the first verifier's onboarding denom to be properly ported",
         );
-        assert_eq!(
-            200,
-            verifier_1.fee_amount.u128(),
-            "expected the first verifier's fee amount to be properly derived",
-        );
         let fee_destination_1 = assert_single_item_by(
             &verifier_1.fee_destinations,
             "expected only a single fee destination to be ported with the address 'fee-destination-1'",
@@ -656,11 +636,6 @@ mod tests {
         assert_eq!(
             "noucoin", verifier_2.onboarding_denom,
             "expected the second verifier's onboarding denom to be properly derived",
-        );
-        assert_eq!(
-            4,
-            verifier_2.fee_amount.u128(),
-            "expected the second verifier's fee amount to be properly derived",
         );
         let fee_destination = assert_single_item(
             &verifier_2.fee_destinations,

--- a/src/core/types/asset_definition.rs
+++ b/src/core/types/asset_definition.rs
@@ -2,6 +2,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::core::types::serialized_enum::SerializedEnum;
+use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::{
     core::state::config_read_v2,
     util::{
@@ -13,6 +14,7 @@ use crate::{
 
 use super::verifier_detail::VerifierDetail;
 
+// TODO: Delete after upgrading all contract instances to AssetDefinitionV2
 /// Defines a specific asset type associated with the contract.  Allows its specified type to be
 /// onboarded and verified.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -67,6 +69,7 @@ impl AssetDefinition {
     }
 }
 
+// TODO: Delete after upgrading all contract instances to AssetDefinitionV2
 /// Allows the user to optionally specify the enabled flag on an asset definition, versus forcing
 /// it to be added manually on every request, when it will likely always be specified as `true`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -152,6 +155,152 @@ impl AssetDefinitionInput {
                 .get_scope_spec_address()?,
             self.verifiers.clone(),
         )
+        .to_ok()
+    }
+}
+
+/// Defines a specific asset type associated with the contract.  Allows its specified type to be
+/// onboarded and verified.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct AssetDefinitionV2 {
+    /// The unique name of the asset associated with the definition.
+    pub asset_type: String,
+    /// A link to a scope specification that defines this asset type.
+    pub scope_spec_address: String,
+    /// Individual verifier definitions.  There can be many verifiers for a single asset type.
+    pub verifiers: Vec<VerifierDetailV2>,
+    /// Indicates whether or not the asset definition is enabled for use in the contract.  If disabled,
+    /// requests to onboard assets of this type will be rejected.
+    pub enabled: bool,
+}
+impl AssetDefinitionV2 {
+    /// Constructs a new instance of AssetDefinitionV2, setting enabled to `true` by default.
+    ///
+    /// # Parameters
+    ///
+    /// * `asset_type` The unique name of the asset associated with the definition.
+    /// * `scope_spec_address` A link to a scope specification that defines this asset type.
+    /// * `verifiers` Individual verifier definitions.
+    pub fn new<S1: Into<String>, S2: Into<String>>(
+        asset_type: S1,
+        scope_spec_address: S2,
+        verifiers: Vec<VerifierDetailV2>,
+    ) -> Self {
+        AssetDefinitionV2 {
+            asset_type: asset_type.into(),
+            scope_spec_address: scope_spec_address.into(),
+            verifiers,
+            enabled: true,
+        }
+    }
+
+    /// Converts the asset_type value to lowercase and serializes it as bytes,
+    /// then uplifts the value to a vector to allow it to be returned.
+    pub fn storage_key(&self) -> Vec<u8> {
+        self.asset_type.to_lowercase().as_bytes().to_vec()
+    }
+
+    /// Helper functionality to retrieve the base contract name from state and use it to create the
+    /// Provenance Blockchain Attribute Module name for this asset type.
+    ///
+    /// # Parameters
+    ///
+    /// * `deps` A read-only instance of the cosmwasm-provided DepsC value.
+    pub fn attribute_name(&self, deps: &DepsC) -> AssetResult<String> {
+        let state = config_read_v2(deps.storage).load()?;
+        generate_asset_attribute_name(&self.asset_type, state.base_contract_name).to_ok()
+    }
+}
+
+// TODO: Delete after upgrading all contract instances to AssetDefinitionV2
+/// Allows the user to optionally specify the enabled flag on an asset definition, versus forcing
+/// it to be added manually on every request, when it will likely always be specified as `true`.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct AssetDefinitionInputV2 {
+    /// The name of the asset associated with the definition.  This value must be unique across all
+    /// instances persisted in contract storage, or requests to add will be rejected.
+    pub asset_type: String,
+    /// A link to a scope specification that defines this asset type.  A serialized version of a
+    /// [ScopeSpecIdentifier](super::scope_spec_identifier::ScopeSpecIdentifier) that allows multiple
+    /// different values to be derived as a scope specification address.  Must be unique across all
+    /// instances persisted in contract storage, or requests to add will be rejected.
+    pub scope_spec_identifier: SerializedEnum,
+    /// Individual verifier definitions.  There can be many verifiers for a single asset type.  Each
+    /// value must have a unique `address` property or requests to add will be rejected.
+    pub verifiers: Vec<VerifierDetailV2>,
+    /// Indicates whether or not the asset definition is enabled for use in the contract.  If disabled,
+    /// requests to onboard assets of this type will be rejected.
+    pub enabled: Option<bool>,
+    /// Whether or not to bind a Provenance Blockchain Name Module name to this contract when this
+    /// struct is used to add a new asset type to the contract.  If this value is omitted OR set to
+    /// true in a request that adds an asset definition, the name derived by combining the
+    /// [base_contract_name](crate::core::state::StateV2::base_contract_name) and the `asset_type`
+    /// will be bound to the contract.  For example, if the base name is "pb" and the asset type is
+    /// "myasset," the resulting bound name would be "myasset.pb".
+    pub bind_name: Option<bool>,
+}
+impl AssetDefinitionInputV2 {
+    /// Constructs a new instance of this struct.
+    ///
+    /// # Parameters
+    ///
+    /// * `asset_type` The name of the asset associated with the definition.  This value must be unique across all
+    /// instances persisted in contract storage, or requests to add will be rejected.
+    /// * `scope_spec_identifier` A link to a scope specification that defines this asset type.
+    /// A serialized version of a [ScopeSpecIdentifier](super::scope_spec_identifier::ScopeSpecIdentifier) that allows multiple
+    /// different values to be derived as a scope specification address.  Must be unique across all
+    /// instances persisted in contract storage, or requests to add will be rejected.
+    /// * `verifiers` Individual verifier definitions.  There can be many verifiers for a single asset type.  Each
+    /// value must have a unique `address` property or requests to add will be rejected.
+    /// * `enabled` Indicates whether or not the asset definition is enabled for use in the contract.  If disabled,
+    /// requests to onboard assets of this type will be rejected.
+    /// * `bind_name` Whether or not to bind a Provenance Blockchain Name Module name to this contract when this
+    /// struct is used to add a new asset type to the contract.
+    pub fn new<S1: Into<String>>(
+        asset_type: S1,
+        scope_spec_identifier: SerializedEnum,
+        verifiers: Vec<VerifierDetailV2>,
+        enabled: Option<bool>,
+        bind_name: Option<bool>,
+    ) -> Self {
+        Self {
+            asset_type: asset_type.into(),
+            scope_spec_identifier,
+            verifiers,
+            enabled,
+            bind_name,
+        }
+    }
+
+    /// Moves this struct into an instance of [AssetDefinitionV2](self::AssetDefinitionV2), converting
+    /// the contained `scope_spec_identifier` enum value into a string scope spec address.
+    pub fn into_asset_definition(self) -> AssetResult<AssetDefinitionV2> {
+        AssetDefinitionV2 {
+            asset_type: self.asset_type,
+            scope_spec_address: self
+                .scope_spec_identifier
+                .to_scope_spec_identifier()?
+                .get_scope_spec_address()?,
+            verifiers: self.verifiers,
+            enabled: self.enabled.unwrap_or(true),
+        }
+        .to_ok()
+    }
+
+    /// Clones the values contained within this struct into an instance of [AssetDefinitionV2](self::AssetDefinitionV2).
+    /// This process is more expensive than moving the struct with [into_asset_definition](self::AssetDefinitionInputV2::into_asset_definition).
+    pub fn as_asset_definition(&self) -> AssetResult<AssetDefinitionV2> {
+        AssetDefinitionV2 {
+            asset_type: self.asset_type.clone(),
+            scope_spec_address: self
+                .scope_spec_identifier
+                .to_scope_spec_identifier()?
+                .get_scope_spec_address()?,
+            verifiers: self.verifiers.clone(),
+            enabled: self.enabled.unwrap_or(true),
+        }
         .to_ok()
     }
 }

--- a/src/core/types/asset_definition.rs
+++ b/src/core/types/asset_definition.rs
@@ -67,6 +67,19 @@ impl AssetDefinition {
         let state = config_read_v2(deps.storage).load()?;
         generate_asset_attribute_name(&self.asset_type, state.base_contract_name).to_ok()
     }
+
+    pub fn to_v2(self) -> AssetDefinitionV2 {
+        AssetDefinitionV2 {
+            asset_type: self.asset_type,
+            scope_spec_address: self.scope_spec_address,
+            verifiers: self
+                .verifiers
+                .into_iter()
+                .map(|verifier| verifier.to_v2())
+                .collect(),
+            enabled: self.enabled,
+        }
+    }
 }
 
 // TODO: Delete after upgrading all contract instances to AssetDefinitionV2
@@ -302,5 +315,386 @@ impl AssetDefinitionInputV2 {
             enabled: self.enabled.unwrap_or(true),
         }
         .to_ok()
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "enable-test-utils")]
+mod tests {
+    use crate::core::types::asset_definition::AssetDefinition;
+    use crate::core::types::entity_detail::EntityDetail;
+    use crate::core::types::fee_destination::FeeDestination;
+    use crate::core::types::verifier_detail::VerifierDetail;
+    use crate::testutil::test_utilities::{assert_single_item, assert_single_item_by};
+    use crate::util::traits::OptionExtensions;
+    use cosmwasm_std::{Decimal, Uint128};
+
+    #[test]
+    fn test_to_v2_for_no_fees() {
+        let definition = AssetDefinition {
+            asset_type: "heloc".to_string(),
+            scope_spec_address: "scope-spec-address".to_string(),
+            verifiers: vec![VerifierDetail {
+                address: "verifier-address".to_string(),
+                onboarding_cost: Uint128::new(100),
+                onboarding_denom: "nhash".to_string(),
+                fee_percent: Decimal::zero(),
+                fee_destinations: vec![],
+                entity_detail: get_valid_entity_detail().to_some(),
+            }],
+            enabled: true,
+        };
+        let v2 = definition.to_v2();
+        assert_eq!(
+            "heloc", v2.asset_type,
+            "expected the asset type to be properly ported",
+        );
+        assert_eq!(
+            "scope-spec-address", v2.scope_spec_address,
+            "expected the scope spec address to be properly ported",
+        );
+        let verifier = assert_single_item(
+            &v2.verifiers,
+            "expected only a single verifier to be ported",
+        );
+        assert_eq!(
+            "verifier-address", verifier.address,
+            "expected the verifier address to be properly ported",
+        );
+        assert_eq!(
+            100,
+            verifier.onboarding_cost.u128(),
+            "expected the verifier onboarding cost to be properly ported",
+        );
+        assert_eq!(
+            "nhash", verifier.onboarding_denom,
+            "expected the verifier onboarding denom to be properly ported",
+        );
+        assert_eq!(
+            0,
+            verifier.fee_amount.u128(),
+            "expected the verifier fee amount to be properly ported",
+        );
+        assert!(
+            verifier.fee_destinations.is_empty(),
+            "expected no fee destinations to be ported",
+        );
+        assert_eq!(
+            get_valid_entity_detail(),
+            verifier
+                .entity_detail
+                .expect("expected the entity detail to be present in the ported value"),
+            "expected the entity detail to be properly ported",
+        );
+    }
+
+    #[test]
+    fn test_to_v2_with_one_fee_destination() {
+        let definition = AssetDefinition {
+            asset_type: "heloc".to_string(),
+            scope_spec_address: "scope-spec-address".to_string(),
+            verifiers: vec![VerifierDetail {
+                address: "verifier-address".to_string(),
+                onboarding_cost: Uint128::new(150),
+                onboarding_denom: "nhash".to_string(),
+                fee_percent: Decimal::percent(50),
+                fee_destinations: vec![FeeDestination::new(
+                    "fee-destination",
+                    Decimal::percent(100),
+                )],
+                entity_detail: get_valid_entity_detail().to_some(),
+            }],
+            enabled: true,
+        };
+        let v2 = definition.to_v2();
+        assert_eq!(
+            "heloc", v2.asset_type,
+            "expected the asset type to be properly ported",
+        );
+        assert_eq!(
+            "scope-spec-address", v2.scope_spec_address,
+            "expected the scope spec address to be properly ported",
+        );
+        let verifier = assert_single_item(
+            &v2.verifiers,
+            "expected only a single verifier to be ported",
+        );
+        assert_eq!(
+            "verifier-address", verifier.address,
+            "expected the verifier address to be properly ported",
+        );
+        assert_eq!(
+            150,
+            verifier.onboarding_cost.u128(),
+            "expected the verifier onboarding cost to be properly ported",
+        );
+        assert_eq!(
+            "nhash", verifier.onboarding_denom,
+            "expected the verifier onboarding denom to be properly ported",
+        );
+        assert_eq!(
+            75,
+            verifier.fee_amount.u128(),
+            "expected the verifier fee amount to be properly derived",
+        );
+        let fee_destination = assert_single_item(
+            &verifier.fee_destinations,
+            "expected a single fee destination to be ported",
+        );
+        assert_eq!(
+            "fee-destination", fee_destination.address,
+            "expected the fee destination address to be properly ported",
+        );
+        assert_eq!(
+            75,
+            fee_destination.fee_amount.u128(),
+            "expected the fee destination's fee amount to be properly derived",
+        );
+        assert!(
+            fee_destination.entity_detail.is_none(),
+            "expected no entity detail to be populated on the fee destination",
+        );
+        assert_eq!(
+            get_valid_entity_detail(),
+            verifier
+                .entity_detail
+                .expect("expected the entity detail to be present in the ported value"),
+            "expected the entity detail to be properly ported",
+        );
+    }
+
+    #[test]
+    fn test_to_v2_with_multiple_fee_destinations() {
+        let definition = AssetDefinition {
+            asset_type: "mortgage".to_string(),
+            scope_spec_address: "scope-spec-address".to_string(),
+            verifiers: vec![VerifierDetail {
+                address: "verifier-address".to_string(),
+                onboarding_cost: Uint128::new(1000),
+                onboarding_denom: "nhash".to_string(),
+                fee_percent: Decimal::percent(20),
+                fee_destinations: vec![
+                    FeeDestination::new("fee-destination-1", Decimal::percent(75)),
+                    FeeDestination::new("fee-destination-2", Decimal::percent(25)),
+                ],
+                entity_detail: get_valid_entity_detail().to_some(),
+            }],
+            enabled: true,
+        };
+        let v2 = definition.to_v2();
+        assert_eq!(
+            "mortgage", v2.asset_type,
+            "expected the asset type to be properly ported",
+        );
+        assert_eq!(
+            "scope-spec-address", v2.scope_spec_address,
+            "expected the scope spec address to be properly ported",
+        );
+        let verifier = assert_single_item(
+            &v2.verifiers,
+            "expected only a single verifier to be ported",
+        );
+        assert_eq!(
+            "verifier-address", verifier.address,
+            "expected the verifier address to be properly ported",
+        );
+        assert_eq!(
+            1000,
+            verifier.onboarding_cost.u128(),
+            "expected the verifier onboarding cost to be properly ported",
+        );
+        assert_eq!(
+            "nhash", verifier.onboarding_denom,
+            "expected the verifier onboarding denom to be properly ported",
+        );
+        assert_eq!(
+            200,
+            verifier.fee_amount.u128(),
+            "expected the verifier fee amount to be properly derived",
+        );
+        let fee_destination_1 = assert_single_item_by(
+            &verifier.fee_destinations,
+            "expected only a single fee destination to be ported with the address 'fee-destination-1'",
+            |dest| dest.address == "fee-destination-1",
+        );
+        assert_eq!(
+            150,
+            fee_destination_1.fee_amount.u128(),
+            "expected the first fee destination's fee amount to be properly derived",
+        );
+        assert!(
+            fee_destination_1.entity_detail.is_none(),
+            "expected no entity detail to be populated on the first fee destination",
+        );
+        let fee_destination_2 = assert_single_item_by(
+            &verifier.fee_destinations,
+            "expected only a single fee destination to be ported with address 'fee-destination-2'",
+            |dest| dest.address == "fee-destination-2",
+        );
+        assert_eq!(
+            50,
+            fee_destination_2.fee_amount.u128(),
+            "expected the second fee destination's fee amount to be properly derived",
+        );
+        assert!(
+            fee_destination_2.entity_detail.is_none(),
+            "expected no entity detail to be populated on the second fee destination",
+        );
+        assert_eq!(
+            get_valid_entity_detail(),
+            verifier
+                .entity_detail
+                .expect("expected the entity detail to be present in the ported value"),
+            "expected the entity detail to be properly ported",
+        );
+    }
+
+    #[test]
+    fn test_to_v2_with_multiple_verifiers() {
+        let definition = AssetDefinition {
+            asset_type: "pl".to_string(),
+            scope_spec_address: "scope-spec-address".to_string(),
+            verifiers: vec![
+                VerifierDetail {
+                    address: "verifier-address-1".to_string(),
+                    onboarding_cost: Uint128::new(1000),
+                    onboarding_denom: "nhash".to_string(),
+                    fee_percent: Decimal::percent(20),
+                    fee_destinations: vec![
+                        FeeDestination::new("fee-destination-1", Decimal::percent(75)),
+                        FeeDestination::new("fee-destination-2", Decimal::percent(25)),
+                    ],
+                    entity_detail: get_valid_entity_detail().to_some(),
+                },
+                VerifierDetail {
+                    address: "verifier-address-2".to_string(),
+                    onboarding_cost: Uint128::new(200),
+                    onboarding_denom: "noucoin".to_string(),
+                    fee_percent: Decimal::percent(2),
+                    fee_destinations: vec![FeeDestination::new(
+                        "fee-destination",
+                        Decimal::percent(100),
+                    )],
+                    entity_detail: None,
+                },
+            ],
+            enabled: true,
+        };
+        let v2 = definition.to_v2();
+        assert_eq!(
+            "pl", v2.asset_type,
+            "expected the asset type to be properly ported",
+        );
+        assert_eq!(
+            "scope-spec-address", v2.scope_spec_address,
+            "expected the scope spec address to be properly ported",
+        );
+        let verifier_1 = assert_single_item_by(
+            &v2.verifiers,
+            "expected only a single verifier to be ported with address 'verifier-address-1'",
+            |verifier| verifier.address == "verifier-address-1",
+        );
+        assert_eq!(
+            1000,
+            verifier_1.onboarding_cost.u128(),
+            "expected the first verifier's onboarding cost to be properly ported",
+        );
+        assert_eq!(
+            "nhash", verifier_1.onboarding_denom,
+            "expected the first verifier's onboarding denom to be properly ported",
+        );
+        assert_eq!(
+            200,
+            verifier_1.fee_amount.u128(),
+            "expected the first verifier's fee amount to be properly derived",
+        );
+        let fee_destination_1 = assert_single_item_by(
+            &verifier_1.fee_destinations,
+            "expected only a single fee destination to be ported with the address 'fee-destination-1'",
+            |dest| dest.address == "fee-destination-1",
+        );
+        assert_eq!(
+            150,
+            fee_destination_1.fee_amount.u128(),
+            "expected the first fee destination's fee amount to be properly derived",
+        );
+        assert!(
+            fee_destination_1.entity_detail.is_none(),
+            "expected no entity detail to be populated on the first fee destination",
+        );
+        let fee_destination_2 = assert_single_item_by(
+            &verifier_1.fee_destinations,
+            "expected only a single fee destination to be ported with address 'fee-destination-2'",
+            |dest| dest.address == "fee-destination-2",
+        );
+        assert_eq!(
+            50,
+            fee_destination_2.fee_amount.u128(),
+            "expected the second fee destination's fee amount to be properly derived",
+        );
+        assert!(
+            fee_destination_2.entity_detail.is_none(),
+            "expected no entity detail to be populated on the second fee destination",
+        );
+        assert_eq!(
+            get_valid_entity_detail(),
+            verifier_1
+                .entity_detail
+                .expect("expected the entity detail to be present in the ported value for the first verifier"),
+            "expected the entity detail for the first verifier to be properly ported",
+        );
+        let verifier_2 = assert_single_item_by(
+            &v2.verifiers,
+            "expected only a single verifier to be ported with address 'verifier-address-2'",
+            |verifier| verifier.address == "verifier-address-2",
+        );
+        assert_eq!(
+            200,
+            verifier_2.onboarding_cost.u128(),
+            "expected the second verifier's onboarding cost to be properly ported",
+        );
+        assert_eq!(
+            "noucoin", verifier_2.onboarding_denom,
+            "expected the second verifier's onboarding denom to be properly derived",
+        );
+        assert_eq!(
+            4,
+            verifier_2.fee_amount.u128(),
+            "expected the second verifier's fee amount to be properly derived",
+        );
+        let fee_destination = assert_single_item(
+            &verifier_2.fee_destinations,
+            "expected only a single fee destination to be ported for the second verifier",
+        );
+        assert_eq!(
+            "fee-destination", fee_destination.address,
+            "expected the fee destination's address to be properly ported for the second verifier",
+        );
+        assert_eq!(
+            4,
+            fee_destination.fee_amount.u128(),
+            "expected the fee destination's fee amount to be properly derived",
+        );
+        assert!(
+            fee_destination.entity_detail.is_none(),
+            "expected no entity detail to be populated on the second verifier's fee destination",
+        );
+        assert!(
+            verifier_2.entity_detail.is_none(),
+            "expected the entity detail on the second verifier to not be present",
+        );
+    }
+
+    fn get_valid_entity_detail() -> EntityDetail {
+        EntityDetail {
+            name: "entity-name".to_string().to_some(),
+            description: "description".to_string().to_some(),
+            home_url: "www.website.websiteother.webstuff.com/whatever"
+                .to_string()
+                .to_some(),
+            source_url: "www.github.com/asset-classification-smart-contract/not-real"
+                .to_string()
+                .to_some(),
+        }
     }
 }

--- a/src/core/types/asset_qualifier.rs
+++ b/src/core/types/asset_qualifier.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 const ASSET_TYPE_NAME: &str = "asset_type";
 const SCOPE_SPEC_ADDRESS_NAME: &str = "scope_spec_address";
 
-/// An enum containing different identifiers that can be used to fetch an [AssetDefinition](super::asset_definition::AssetDefinition).
+/// An enum containing different identifiers that can be used to fetch an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AssetQualifier {

--- a/src/core/types/asset_scope_attribute.rs
+++ b/src/core/types/asset_scope_attribute.rs
@@ -2,6 +2,7 @@ use cosmwasm_std::Addr;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::{
     core::{error::ContractError, types::access_definition::AccessDefinitionType},
     util::{
@@ -15,7 +16,7 @@ use crate::{
 use super::{
     access_definition::AccessDefinition, access_route::AccessRoute,
     asset_identifier::AssetIdentifier, asset_onboarding_status::AssetOnboardingStatus,
-    asset_verification_result::AssetVerificationResult, verifier_detail::VerifierDetail,
+    asset_verification_result::AssetVerificationResult,
 };
 
 /// An asset scope attribute contains all relevant information for asset classification, and is serialized directly
@@ -41,7 +42,7 @@ pub struct AssetScopeAttribute {
     /// verifier address chosen by the requestor is added to the scope attribute.  This ensures that
     /// if the verifier values change due to an external update, the original fee structure will be
     /// honored for the onboarding task placed originally.
-    pub latest_verifier_detail: Option<VerifierDetail>,
+    pub latest_verifier_detail: Option<VerifierDetailV2>,
     /// The most recent verification is kept on the scope attribute.  If the verifier determines that
     /// the asset cannot be classified, this value may be overwritten later by a subsequent onboard.
     pub latest_verification_result: Option<AssetVerificationResult>,
@@ -78,7 +79,7 @@ impl AssetScopeAttribute {
         requestor_address: S2,
         verifier_address: S3,
         onboarding_status: Option<AssetOnboardingStatus>,
-        latest_verifier_detail: VerifierDetail,
+        latest_verifier_detail: VerifierDetailV2,
         access_routes: Vec<AccessRoute>,
     ) -> AssetResult<Self> {
         let identifiers = identifier.to_identifiers()?;

--- a/src/core/types/fee_destination.rs
+++ b/src/core/types/fee_destination.rs
@@ -3,6 +3,7 @@ use crate::util::traits::OptionExtensions;
 use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::ops::Mul;
 
 // TODO: Delete after upgrading all contract instances to FeeDestinationV2
 /// Defines an external account designated as a recipient of funds during the verification process.
@@ -31,6 +32,15 @@ impl FeeDestination {
         FeeDestination {
             address: address.into(),
             fee_percent,
+        }
+    }
+
+    pub fn to_v2(self, total_fee_cost: u128) -> FeeDestinationV2 {
+        FeeDestinationV2 {
+            address: self.address,
+            fee_amount: Uint128::new(total_fee_cost).mul(self.fee_percent),
+            // New field that can't have ever been set, so just start it out as unset
+            entity_detail: None,
         }
     }
 }

--- a/src/core/types/fee_destination.rs
+++ b/src/core/types/fee_destination.rs
@@ -1,3 +1,5 @@
+use crate::core::types::entity_detail::EntityDetail;
+use crate::util::traits::OptionExtensions;
 use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -44,6 +46,8 @@ pub struct FeeDestinationV2 {
     /// always be less than or equal to the fee amount, and all fee destinations on a verifier
     /// detail should sum to the specified fee amount.
     pub fee_amount: Uint128,
+    /// An optional set of fields that define the fee destination, including its name and home URL location.
+    pub entity_detail: Option<EntityDetail>,
 }
 impl FeeDestinationV2 {
     /// Constructs a new instance of this struct.
@@ -54,9 +58,31 @@ impl FeeDestinationV2 {
     /// * `fee_amount` The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount)
     /// of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).
     pub fn new<S: Into<String>>(address: S, fee_amount: Uint128) -> Self {
-        FeeDestinationV2 {
+        Self {
             address: address.into(),
             fee_amount,
+            entity_detail: None,
+        }
+    }
+
+    /// Constructs a new instance of this struct with an entity detail.
+    ///
+    /// # Parameters
+    ///
+    /// * `address` The Provenance Blockchain bech32 address belonging to the account.
+    /// * `fee_amount` The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount)
+    /// of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).
+    /// * `entity_detail` An optional set of fields that define the fee destination, including its
+    /// name and home URL location.
+    pub fn new_with_detail<S: Into<String>>(
+        address: S,
+        fee_amount: Uint128,
+        entity_detail: EntityDetail,
+    ) -> Self {
+        Self {
+            address: address.into(),
+            fee_amount,
+            entity_detail: entity_detail.to_some(),
         }
     }
 }

--- a/src/core/types/fee_destination.rs
+++ b/src/core/types/fee_destination.rs
@@ -51,10 +51,10 @@ impl FeeDestination {
 pub struct FeeDestinationV2 {
     /// The Provenance Blockchain bech32 address belonging to the account.
     pub address: String,
-    /// The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the
+    /// The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost) of the
     /// containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should
-    /// always be less than or equal to the fee amount, and all fee destinations on a verifier
-    /// detail should sum to the specified fee amount.
+    /// always sum with the other fee destinations to be less than or at most equal to the total
+    /// onboarding cost.
     pub fee_amount: Uint128,
     /// An optional set of fields that define the fee destination, including its name and home URL location.
     pub entity_detail: Option<EntityDetail>,
@@ -65,7 +65,7 @@ impl FeeDestinationV2 {
     /// # Parameters
     ///
     /// * `address` The Provenance Blockchain bech32 address belonging to the account.
-    /// * `fee_amount` The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount)
+    /// * `fee_amount` The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost)
     /// of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).
     pub fn new<S: Into<String>>(address: S, fee_amount: Uint128) -> Self {
         Self {
@@ -80,7 +80,7 @@ impl FeeDestinationV2 {
     /// # Parameters
     ///
     /// * `address` The Provenance Blockchain bech32 address belonging to the account.
-    /// * `fee_amount` The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount)
+    /// * `fee_amount` The amount to be distributed to this account from the designated total [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost)
     /// of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).
     /// * `entity_detail` An optional set of fields that define the fee destination, including its
     /// name and home URL location.

--- a/src/core/types/fee_destination.rs
+++ b/src/core/types/fee_destination.rs
@@ -1,7 +1,8 @@
-use cosmwasm_std::Decimal;
+use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+// TODO: Delete after upgrading all contract instances to FeeDestinationV2
 /// Defines an external account designated as a recipient of funds during the verification process.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -28,6 +29,34 @@ impl FeeDestination {
         FeeDestination {
             address: address.into(),
             fee_percent,
+        }
+    }
+}
+
+/// Defines an external account designated as a recipient of funds during the verification process.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct FeeDestinationV2 {
+    /// The Provenance Blockchain bech32 address belonging to the account.
+    pub address: String,
+    /// The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount) of the
+    /// containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).  This number should
+    /// always be less than or equal to the fee amount, and all fee destinations on a verifier
+    /// detail should sum to the specified fee amount.
+    pub fee_amount: Uint128,
+}
+impl FeeDestinationV2 {
+    /// Constructs a new instance of this struct.
+    ///
+    /// # Parameters
+    ///
+    /// * `address` The Provenance Blockchain bech32 address belonging to the account.
+    /// * `fee_amount` The amount to be distributed to this account from the designated total [fee_amount](super::verifier_detail::VerifierDetailV2::fee_amount)
+    /// of the containing [VerifierDetailV2](super::verifier_detail::VerifierDetailV2).
+    pub fn new<S: Into<String>>(address: S, fee_amount: Uint128) -> Self {
+        FeeDestinationV2 {
+            address: address.into(),
+            fee_amount,
         }
     }
 }

--- a/src/core/types/mod.rs
+++ b/src/core/types/mod.rs
@@ -10,7 +10,7 @@ pub mod asset_definition;
 pub mod asset_identifier;
 /// An enum that denotes the various states that an [AssetScopeAttribute](self::asset_scope_attribute::AssetScopeAttribute) can have.
 pub mod asset_onboarding_status;
-/// An enum containing different identifiers that can be used to fetch an [AssetDefinition](self::asset_definition::AssetDefinition).
+/// An enum containing different identifiers that can be used to fetch an [AssetDefinitionV2](self::asset_definition::AssetDefinitionV2).
 pub mod asset_qualifier;
 /// An asset scope attribute contains all relevant information for asset classification, and is serialized directly
 /// as json into a Provenance Blockchain Attribute Module attribute on a Provenance Blockchain Metadata Scope.
@@ -26,5 +26,5 @@ pub mod scope_spec_identifier;
 /// A simple struct that allows a type and value to be translated to some of the optional enums in the contract:
 /// [AssetIdentifier](self::asset_identifier::AssetIdentifier), [AssetQualifier](self::asset_qualifier::AssetQualifier), and [ScopeSpecIdentifier](self::scope_spec_identifier::ScopeSpecIdentifier).
 pub mod serialized_enum;
-/// Defines the fees and addresses for a single verifier account for an [AssetDefinition](self::asset_definition::AssetDefinition).
+/// Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](self::asset_definition::AssetDefinitionV2).
 pub mod verifier_detail;

--- a/src/core/types/verifier_detail.rs
+++ b/src/core/types/verifier_detail.rs
@@ -1,9 +1,11 @@
+use crate::core::types::fee_destination::FeeDestinationV2;
 use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{entity_detail::EntityDetail, fee_destination::FeeDestination};
 
+// TODO: Delete after upgrading all contract instances to VerifierDetailV2
 /// Defines the fees and addresses for a single verifier account for an [AssetDefinition](super::asset_definition::AssetDefinition).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -51,6 +53,61 @@ impl VerifierDetail {
             onboarding_cost,
             onboarding_denom: onboarding_denom.into(),
             fee_percent,
+            fee_destinations,
+            entity_detail,
+        }
+    }
+}
+
+/// Defines the fees and addresses for a single verifier account for an [AssetDefinitionV2](super::asset_definition::AssetDefinitionV2).
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct VerifierDetailV2 {
+    /// The Provenance Blockchain bech32 address of the verifier account.
+    pub address: String,
+    /// The total amount charged to use the onboarding process this this verifier.
+    pub onboarding_cost: Uint128,
+    /// The coin denomination used for this onboarding process.
+    pub onboarding_denom: String,
+    /// The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost)
+    /// to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should
+    /// never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost)
+    /// itself.
+    pub fee_amount: Uint128,
+    /// Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount).
+    /// All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties
+    /// should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not
+    /// precisely equal in sum will cause this verifier detail to be considered invalid and rejected
+    /// in requests that include it.
+    pub fee_destinations: Vec<FeeDestinationV2>,
+    /// An optional set of fields that define the verifier, including its name and home URL location.
+    pub entity_detail: Option<EntityDetail>,
+}
+impl VerifierDetailV2 {
+    /// Constructs a new instance of this struct.
+    ///
+    /// # Parameters
+    ///
+    /// * `address` The Provenance Blockchain bech32 address of the verifier account.
+    /// * `onboarding_cost` The total amount charged to use the onboarding process this this verifier.
+    /// * `onboarding_denom` The coin denomination used for this onboarding process.
+    /// * `fee_amount` The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost)
+    /// to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2).
+    /// `fee_destinations` Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount).
+    /// `entity_detail` An optional set of fields that define the verifier, including its name and home URL location.
+    pub fn new<S1: Into<String>, S2: Into<String>>(
+        address: S1,
+        onboarding_cost: Uint128,
+        onboarding_denom: S2,
+        fee_amount: Uint128,
+        fee_destinations: Vec<FeeDestinationV2>,
+        entity_detail: Option<EntityDetail>,
+    ) -> Self {
+        VerifierDetailV2 {
+            address: address.into(),
+            onboarding_cost,
+            onboarding_denom: onboarding_denom.into(),
+            fee_amount,
             fee_destinations,
             entity_detail,
         }

--- a/src/core/types/verifier_detail.rs
+++ b/src/core/types/verifier_detail.rs
@@ -65,7 +65,6 @@ impl VerifierDetail {
             address: self.address,
             onboarding_cost: self.onboarding_cost,
             onboarding_denom: self.onboarding_denom,
-            fee_amount: total_fee_cost,
             fee_destinations: self
                 .fee_destinations
                 .into_iter()
@@ -86,16 +85,11 @@ pub struct VerifierDetailV2 {
     pub onboarding_cost: Uint128,
     /// The coin denomination used for this onboarding process.
     pub onboarding_denom: String,
-    /// The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost)
-    /// to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2). This should
-    /// never be a larger amount than the [onboarding_cost](self::VerifierDetailV2::onboarding_cost)
-    /// itself.
-    pub fee_amount: Uint128,
-    /// Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount).
+    /// Each account that should receive fees when onboarding a new scope to the contract.
     /// All of these destinations' individual [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) properties
-    /// should sum to the specified [fee_amount](self::VerifierDetailV2::fee_amount).  Amounts not
-    /// precisely equal in sum will cause this verifier detail to be considered invalid and rejected
-    /// in requests that include it.
+    /// should sum to an amount less than or equal to the [onboarding_cost](super::verifier_detail::VerifierDetailV2::onboarding_cost).
+    /// Amounts not precisely equal in sum will cause this verifier detail to be considered invalid
+    /// and rejected in requests that include it.
     pub fee_destinations: Vec<FeeDestinationV2>,
     /// An optional set of fields that define the verifier, including its name and home URL location.
     pub entity_detail: Option<EntityDetail>,
@@ -108,15 +102,12 @@ impl VerifierDetailV2 {
     /// * `address` The Provenance Blockchain bech32 address of the verifier account.
     /// * `onboarding_cost` The total amount charged to use the onboarding process this this verifier.
     /// * `onboarding_denom` The coin denomination used for this onboarding process.
-    /// * `fee_amount` The amount taken from the total [onboarding_cost](self::VerifierDetailV2::onboarding_cost)
-    /// to send to the underlying [FeeDestinationV2s](super::fee_destination::FeeDestinationV2).
-    /// `fee_destinations` Each account that should receive the amount designated in the [fee_amount](self::VerifierDetailV2::fee_amount).
-    /// `entity_detail` An optional set of fields that define the verifier, including its name and home URL location.
+    /// * `fee_destinations` Each account that should receive some (or all) of the amount specified in [onboarding_cost](self::VerifierDetailV2::onboarding_cost).
+    /// * `entity_detail` An optional set of fields that define the verifier, including its name and home URL location.
     pub fn new<S1: Into<String>, S2: Into<String>>(
         address: S1,
         onboarding_cost: Uint128,
         onboarding_denom: S2,
-        fee_amount: Uint128,
         fee_destinations: Vec<FeeDestinationV2>,
         entity_detail: Option<EntityDetail>,
     ) -> Self {
@@ -124,9 +115,18 @@ impl VerifierDetailV2 {
             address: address.into(),
             onboarding_cost,
             onboarding_denom: onboarding_denom.into(),
-            fee_amount,
             fee_destinations,
             entity_detail,
         }
+    }
+
+    /// Calculates a sum of all held [fee_destinations](self::VerifierDetailV2::fee_destinations)
+    /// respective [fee_amount](super::fee_destination::FeeDestinationV2::fee_amount) fields.
+    ///
+    pub fn get_fee_total(&self) -> u128 {
+        self.fee_destinations
+            .iter()
+            .map(|d| d.fee_amount.u128())
+            .sum::<u128>()
     }
 }

--- a/src/core/types/verifier_detail.rs
+++ b/src/core/types/verifier_detail.rs
@@ -130,3 +130,58 @@ impl VerifierDetailV2 {
             .sum::<u128>()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::core::types::fee_destination::FeeDestinationV2;
+    use crate::core::types::verifier_detail::VerifierDetailV2;
+    use crate::util::constants::NHASH;
+    use cosmwasm_std::Uint128;
+
+    #[test]
+    fn test_no_fee_destinations_fee_total() {
+        let verifier = VerifierDetailV2::new("address", Uint128::new(100), NHASH, vec![], None);
+        assert_eq!(
+            0,
+            verifier.get_fee_total(),
+            "expected the fee total to be zero when no fee definitions are listed",
+        );
+    }
+
+    #[test]
+    fn test_one_fee_destination_fee_total() {
+        let verifier = VerifierDetailV2::new(
+            "address",
+            Uint128::new(100),
+            NHASH,
+            vec![FeeDestinationV2::new("fee-address", Uint128::new(55))],
+            None,
+        );
+        assert_eq!(
+            55, verifier.get_fee_total(),
+            "expected the fee total to directly reflect the amount listed in the single fee destination",
+        );
+    }
+
+    #[test]
+    fn test_many_fee_destinations_fee_total() {
+        let verifier = VerifierDetailV2::new(
+            "address",
+            Uint128::new(1000),
+            NHASH,
+            vec![
+                FeeDestinationV2::new("fee-address-1", Uint128::new(10)),
+                FeeDestinationV2::new("fee-address-2", Uint128::new(20)),
+                FeeDestinationV2::new("fee-address-3", Uint128::new(30)),
+                FeeDestinationV2::new("fee-address-4", Uint128::new(40)),
+                FeeDestinationV2::new("fee-address-5", Uint128::new(50)),
+                FeeDestinationV2::new("fee-address-6", Uint128::new(60)),
+            ],
+            None,
+        );
+        assert_eq!(
+            210, verifier.get_fee_total(),
+            "expected the fee total to be the sum of all fee destinations' fee amounts (10 + 20 + 30 + 40 + 50 + 60 = 210)",
+        );
+    }
+}

--- a/src/core/types/verifier_detail.rs
+++ b/src/core/types/verifier_detail.rs
@@ -2,6 +2,7 @@ use crate::core::types::fee_destination::FeeDestinationV2;
 use cosmwasm_std::{Decimal, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use std::ops::Mul;
 
 use super::{entity_detail::EntityDetail, fee_destination::FeeDestination};
 
@@ -55,6 +56,22 @@ impl VerifierDetail {
             fee_percent,
             fee_destinations,
             entity_detail,
+        }
+    }
+
+    pub fn to_v2(self) -> VerifierDetailV2 {
+        let total_fee_cost = self.onboarding_cost.mul(self.fee_percent);
+        VerifierDetailV2 {
+            address: self.address,
+            onboarding_cost: self.onboarding_cost,
+            onboarding_denom: self.onboarding_denom,
+            fee_amount: total_fee_cost,
+            fee_destinations: self
+                .fee_destinations
+                .into_iter()
+                .map(|dest| dest.to_v2(total_fee_cost.u128()))
+                .collect(),
+            entity_detail: self.entity_detail,
         }
     }
 }

--- a/src/execute/add_asset_definition.rs
+++ b/src/execute/add_asset_definition.rs
@@ -352,7 +352,6 @@ mod tests {
                 DEFAULT_VERIFIER_ADDRESS,
                 Uint128::new(1000),
                 NHASH,
-                Uint128::new(500),
                 vec![FeeDestinationV2::new(
                     DEFAULT_FEE_ADDRESS,
                     Uint128::new(500),

--- a/src/execute/add_asset_verifier.rs
+++ b/src/execute/add_asset_verifier.rs
@@ -223,14 +223,7 @@ mod tests {
             ExecuteMsg::AddAssetVerifier {
                 asset_type: DEFAULT_ASSET_TYPE.to_string(),
                 // Invalid because the address is blank
-                verifier: VerifierDetailV2::new(
-                    "",
-                    Uint128::zero(),
-                    NHASH,
-                    Uint128::zero(),
-                    vec![],
-                    None,
-                ),
+                verifier: VerifierDetailV2::new("", Uint128::zero(), NHASH, vec![], None),
             },
         )
         .unwrap_err();
@@ -288,7 +281,6 @@ mod tests {
                     DEFAULT_VERIFIER_ADDRESS,
                     Uint128::new(100),
                     NHASH,
-                    Uint128::zero(),
                     vec![],
                     None,
                 ),
@@ -319,7 +311,6 @@ mod tests {
             TEST_VERIFIER_ADDRESS,
             Uint128::new(500000),
             NHASH,
-            Uint128::new(500),
             vec![FeeDestinationV2::new(TEST_FEE_ADDRESS, Uint128::new(500))],
             get_default_entity_detail().to_some(),
         );

--- a/src/execute/add_asset_verifier.rs
+++ b/src/execute/add_asset_verifier.rs
@@ -1,7 +1,7 @@
 use crate::core::error::ContractError;
 use crate::core::msg::ExecuteMsg;
-use crate::core::state::{load_asset_definition_by_type, replace_asset_definition};
-use crate::core::types::verifier_detail::VerifierDetail;
+use crate::core::state::{load_asset_definition_v2_by_type, replace_asset_definition_v2};
+use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
 use crate::util::event_attributes::{EventAttributes, EventType};
@@ -13,27 +13,27 @@ use cosmwasm_std::{MessageInfo, Response};
 ///
 /// # Parameters
 ///
-/// * `asset_type` The type of asset, corresponding to the [asset_type](crate::core::types::asset_definition::AssetDefinition::asset_type)
-/// value of an existing [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+/// * `asset_type` The type of asset, corresponding to the [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type)
+/// value of an existing [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
 /// in contract storage.
 /// * `verifier` The verifier detail to use in the [add_asset_verifier](self::add_asset_verifier)
 /// request.
 #[derive(Clone, PartialEq)]
 pub struct AddAssetVerifierV1 {
     pub asset_type: String,
-    pub verifier: VerifierDetail,
+    pub verifier: VerifierDetailV2,
 }
 impl AddAssetVerifierV1 {
     /// Constructs a new instance of this struct.
     ///
     /// # Parameters
     ///
-    /// * `asset_type` The type of asset, corresponding to the [asset_type](crate::core::types::asset_definition::AssetDefinition::asset_type)
-    /// value of an existing [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+    /// * `asset_type` The type of asset, corresponding to the [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type)
+    /// value of an existing [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
     /// in contract storage.
     /// * `verifier` The verifier detail to use in the [add_asset_verifier](self::add_asset_verifier)
     /// request.
-    pub fn new<S: Into<String>>(asset_type: S, verifier: VerifierDetail) -> Self {
+    pub fn new<S: Into<String>>(asset_type: S, verifier: VerifierDetailV2) -> Self {
         AddAssetVerifierV1 {
             asset_type: asset_type.into(),
             verifier,
@@ -63,9 +63,9 @@ impl AddAssetVerifierV1 {
 }
 
 /// The function used by [execute](crate::contract::execute) when an [ExecuteMsg::AddAssetVerifier](crate::core::msg::ExecuteMsg::AddAssetVerifier)
-/// message is provided.  Attempts to add a new [VerifierDetail](crate::core::types::verifier_detail::VerifierDetail)
-/// to an existing [AssetDefinition](crate::core::types::asset_definition::AssetDefinition) if no
-/// verifier exists with a matching [address](crate::core::types::verifier_detail::VerifierDetail::address).
+/// message is provided.  Attempts to add a new [VerifierDetailV2](crate::core::types::verifier_detail::VerifierDetailV2)
+/// to an existing [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2) if no
+/// verifier exists with a matching [address](crate::core::types::verifier_detail::VerifierDetailV2::address).
 ///
 /// # Parameters
 ///
@@ -82,7 +82,7 @@ pub fn add_asset_verifier(
 ) -> EntryPointResponse {
     check_admin_only(&deps.as_ref(), &info)?;
     check_funds_are_empty(&info)?;
-    let mut asset_definition = load_asset_definition_by_type(deps.storage, &msg.asset_type)?;
+    let mut asset_definition = load_asset_definition_v2_by_type(deps.storage, &msg.asset_type)?;
     // If the asset definition has any verifiers on it (only ever should be 1 max) with a matching
     // address to the new verifier, this request should be an update, not an add
     if asset_definition
@@ -98,7 +98,7 @@ pub fn add_asset_verifier(
         .set_verifier(&msg.verifier.address);
     // Store the new verifier in the definition and save it to storage
     asset_definition.verifiers.push(msg.verifier);
-    replace_asset_definition(deps.storage, &asset_definition)?;
+    replace_asset_definition_v2(deps.storage, &asset_definition)?;
     // Respond with emitted attributes
     Response::new().add_attributes(attributes).to_ok()
 }
@@ -109,9 +109,9 @@ mod tests {
     use crate::contract::execute;
     use crate::core::error::ContractError;
     use crate::core::msg::ExecuteMsg;
-    use crate::core::state::load_asset_definition_by_type;
-    use crate::core::types::fee_destination::FeeDestination;
-    use crate::core::types::verifier_detail::VerifierDetail;
+    use crate::core::state::load_asset_definition_v2_by_type;
+    use crate::core::types::fee_destination::FeeDestinationV2;
+    use crate::core::types::verifier_detail::VerifierDetailV2;
     use crate::execute::add_asset_verifier::{add_asset_verifier, AddAssetVerifierV1};
     use crate::testutil::test_constants::{
         DEFAULT_ADMIN_ADDRESS, DEFAULT_ASSET_TYPE, DEFAULT_VERIFIER_ADDRESS,
@@ -127,7 +127,7 @@ mod tests {
     use crate::util::traits::OptionExtensions;
     use crate::validation::validate_init_msg::validate_verifier;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{coin, Decimal, Uint128};
+    use cosmwasm_std::{coin, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     // Addresses must be valid bech32, so these are valid randomly-generated values for testing
@@ -223,11 +223,11 @@ mod tests {
             ExecuteMsg::AddAssetVerifier {
                 asset_type: DEFAULT_ASSET_TYPE.to_string(),
                 // Invalid because the address is blank
-                verifier: VerifierDetail::new(
+                verifier: VerifierDetailV2::new(
                     "",
-                    Uint128::new(0),
+                    Uint128::zero(),
                     NHASH,
-                    Decimal::percent(0),
+                    Uint128::zero(),
                     vec![],
                     None,
                 ),
@@ -284,11 +284,11 @@ mod tests {
             mock_info(DEFAULT_ADMIN_ADDRESS, &[]),
             AddAssetVerifierV1::new(
                 DEFAULT_ASSET_TYPE,
-                VerifierDetail::new(
+                VerifierDetailV2::new(
                     DEFAULT_VERIFIER_ADDRESS,
                     Uint128::new(100),
                     NHASH,
-                    Decimal::percent(0),
+                    Uint128::zero(),
                     vec![],
                     None,
                 ),
@@ -303,8 +303,8 @@ mod tests {
     }
 
     // Checks that the verifier passed in was added to the default asset type's definition
-    fn test_default_verifier_was_added(verifier: &VerifierDetail, deps: &DepsC) {
-        let state_def = load_asset_definition_by_type(deps.storage, DEFAULT_ASSET_TYPE)
+    fn test_default_verifier_was_added(verifier: &VerifierDetailV2, deps: &DepsC) {
+        let state_def = load_asset_definition_v2_by_type(deps.storage, DEFAULT_ASSET_TYPE)
             .expect("expected the default asset type to be stored in the state");
         let target_verifier = state_def.verifiers.into_iter().find(|v| v.address == verifier.address)
             .expect("expected a single verifier to be produced when searching for the new verifier's address");
@@ -314,13 +314,13 @@ mod tests {
         );
     }
 
-    fn get_valid_new_verifier() -> VerifierDetail {
-        let verifier = VerifierDetail::new(
+    fn get_valid_new_verifier() -> VerifierDetailV2 {
+        let verifier = VerifierDetailV2::new(
             TEST_VERIFIER_ADDRESS,
             Uint128::new(500000),
             NHASH,
-            Decimal::percent(10),
-            vec![FeeDestination::new(TEST_FEE_ADDRESS, Decimal::percent(100))],
+            Uint128::new(500),
+            vec![FeeDestinationV2::new(TEST_FEE_ADDRESS, Uint128::new(500))],
             get_default_entity_detail().to_some(),
         );
         validate_verifier(&verifier).expect("expected the new verifier to pass validation");

--- a/src/execute/update_asset_definition.rs
+++ b/src/execute/update_asset_definition.rs
@@ -236,7 +236,6 @@ mod tests {
                 "verifier",
                 Uint128::new(100),
                 NHASH,
-                Uint128::new(25),
                 vec![FeeDestinationV2::new("fee-guy", Uint128::new(25))],
                 get_default_entity_detail().to_some(),
             )],
@@ -284,7 +283,6 @@ mod tests {
                 "tp1y67rma23nplzy8rpvfqsztvktvp85hnmnjvzxs",
                 Uint128::new(1500000),
                 NHASH,
-                Uint128::new(750000),
                 vec![
                     FeeDestinationV2::new(
                         "tp1knh6n2kafm78mfv0c6d6y3x3en3pcdph23r2e7",

--- a/src/execute/update_asset_definition.rs
+++ b/src/execute/update_asset_definition.rs
@@ -1,7 +1,7 @@
 use crate::core::error::ContractError;
 use crate::core::msg::ExecuteMsg;
-use crate::core::state::replace_asset_definition;
-use crate::core::types::asset_definition::AssetDefinition;
+use crate::core::state::replace_asset_definition_v2;
+use crate::core::types::asset_definition::AssetDefinitionV2;
 use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
 use crate::util::event_attributes::{EventAttributes, EventType};
@@ -13,20 +13,20 @@ use cosmwasm_std::{MessageInfo, Response};
 ///
 /// # Parameters
 ///
-/// * `asset_definition` The asset definition instance to update.  Must have an [asset_type](crate::core::types::asset_definition::AssetDefinition::asset_type)
+/// * `asset_definition` The asset definition instance to update.  Must have an [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type)
 /// property that matches an existing asset definition in contract storage.
 #[derive(Clone, PartialEq)]
 pub struct UpdateAssetDefinitionV1 {
-    pub asset_definition: AssetDefinition,
+    pub asset_definition: AssetDefinitionV2,
 }
 impl UpdateAssetDefinitionV1 {
     /// Constructs a new instance of this struct.
     ///
     /// # Parameters
     ///
-    /// * `asset_definition` The asset definition instance to update.  Must have an [asset_type](crate::core::types::asset_definition::AssetDefinition::asset_type)
+    /// * `asset_definition` The asset definition instance to update.  Must have an [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type)
     /// property that matches an existing asset definition in contract storage.
-    pub fn new(asset_definition: AssetDefinition) -> Self {
+    pub fn new(asset_definition: AssetDefinitionV2) -> Self {
         UpdateAssetDefinitionV1 { asset_definition }
     }
 
@@ -53,8 +53,8 @@ impl UpdateAssetDefinitionV1 {
 }
 
 /// The function used by [execute](crate::contract::execute) when an [ExecuteMsg::UpdateAssetDefinition](crate::core::msg::ExecuteMsg::UpdateAssetDefinition)
-/// message is provided.  Attempts to replace an existing [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
-/// value based on a matching [asset_type](crate::core::types::asset_definition::AssetDefinition::asset_type)
+/// message is provided.  Attempts to replace an existing [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
+/// value based on a matching [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type)
 /// property.  If no matching type is present, the request will be rejected.
 ///
 /// # Parameters
@@ -73,7 +73,7 @@ pub fn update_asset_definition(
     check_admin_only(&deps.as_ref(), &info)?;
     check_funds_are_empty(&info)?;
     // Overwrite the existing asset definition with the new one
-    replace_asset_definition(deps.storage, &msg.asset_definition)?;
+    replace_asset_definition_v2(deps.storage, &msg.asset_definition)?;
     Response::new()
         .add_attributes(
             EventAttributes::new(EventType::UpdateAssetDefinition)
@@ -88,11 +88,11 @@ mod tests {
     use crate::contract::execute;
     use crate::core::error::ContractError;
     use crate::core::msg::ExecuteMsg;
-    use crate::core::state::load_asset_definition_by_type;
-    use crate::core::types::asset_definition::{AssetDefinition, AssetDefinitionInput};
-    use crate::core::types::fee_destination::FeeDestination;
+    use crate::core::state::load_asset_definition_v2_by_type;
+    use crate::core::types::asset_definition::{AssetDefinitionInputV2, AssetDefinitionV2};
+    use crate::core::types::fee_destination::FeeDestinationV2;
     use crate::core::types::scope_spec_identifier::ScopeSpecIdentifier;
-    use crate::core::types::verifier_detail::VerifierDetail;
+    use crate::core::types::verifier_detail::VerifierDetailV2;
     use crate::execute::update_asset_definition::{
         update_asset_definition, UpdateAssetDefinitionV1,
     };
@@ -110,7 +110,7 @@ mod tests {
     use crate::util::traits::OptionExtensions;
     use crate::validation::validate_init_msg::validate_asset_definition_input;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{coin, Decimal, Uint128};
+    use cosmwasm_std::{coin, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
@@ -168,7 +168,7 @@ mod tests {
         let mut deps = mock_dependencies(&[]);
         test_instantiate_success(deps.as_mut(), InstArgs::default());
         let msg = ExecuteMsg::UpdateAssetDefinition {
-            asset_definition: AssetDefinitionInput::new(
+            asset_definition: AssetDefinitionInputV2::new(
                 DEFAULT_ASSET_TYPE,
                 ScopeSpecIdentifier::address(DEFAULT_SCOPE_SPEC_ADDRESS).to_serialized_enum(),
                 vec![],
@@ -229,15 +229,15 @@ mod tests {
     fn test_invalid_update_asset_definition_for_missing_loan_type() {
         let mut deps = mock_dependencies(&[]);
         test_instantiate_success(deps.as_mut(), InstArgs::default());
-        let missing_asset_definition = AssetDefinition::new(
+        let missing_asset_definition = AssetDefinitionV2::new(
             "nonexistent-type",
             DEFAULT_SCOPE_SPEC_ADDRESS,
-            vec![VerifierDetail::new(
+            vec![VerifierDetailV2::new(
                 "verifier",
                 Uint128::new(100),
                 NHASH,
-                Decimal::percent(25),
-                vec![FeeDestination::new("fee-guy", Decimal::percent(100))],
+                Uint128::new(25),
+                vec![FeeDestinationV2::new("fee-guy", Uint128::new(25))],
                 get_default_entity_detail().to_some(),
             )],
         );
@@ -254,7 +254,7 @@ mod tests {
         );
     }
 
-    fn test_asset_definition_was_updated_for_input(input: &AssetDefinitionInput, deps: &DepsC) {
+    fn test_asset_definition_was_updated_for_input(input: &AssetDefinitionInputV2, deps: &DepsC) {
         test_asset_definition_was_updated(
             &input
                 .as_asset_definition()
@@ -263,9 +263,10 @@ mod tests {
         )
     }
 
-    fn test_asset_definition_was_updated(asset_definition: &AssetDefinition, deps: &DepsC) {
-        let state_def = load_asset_definition_by_type(deps.storage, &asset_definition.asset_type)
-            .expect("expected the updated asset definition to be stored in the state");
+    fn test_asset_definition_was_updated(asset_definition: &AssetDefinitionV2, deps: &DepsC) {
+        let state_def =
+            load_asset_definition_v2_by_type(deps.storage, &asset_definition.asset_type)
+                .expect("expected the updated asset definition to be stored in the state");
         assert_eq!(
             asset_definition, &state_def,
             "the value in state should directly equate to the added value",
@@ -275,23 +276,23 @@ mod tests {
     // This builds off of the existing default asset definition in test_utilities and adds/tweaks
     // details.  This uses randomly-generated bech32 provenance testnet addresses to be different than
     // the default values
-    fn get_update_asset_definition() -> AssetDefinitionInput {
-        let def = AssetDefinitionInput::new(
+    fn get_update_asset_definition() -> AssetDefinitionInputV2 {
+        let def = AssetDefinitionInputV2::new(
             DEFAULT_ASSET_TYPE,
             ScopeSpecIdentifier::address(DEFAULT_SCOPE_SPEC_ADDRESS).to_serialized_enum(),
-            vec![VerifierDetail::new(
+            vec![VerifierDetailV2::new(
                 "tp1y67rma23nplzy8rpvfqsztvktvp85hnmnjvzxs",
                 Uint128::new(1500000),
                 NHASH,
-                Decimal::percent(50),
+                Uint128::new(750000),
                 vec![
-                    FeeDestination::new(
+                    FeeDestinationV2::new(
                         "tp1knh6n2kafm78mfv0c6d6y3x3en3pcdph23r2e7",
-                        Decimal::percent(70),
+                        Uint128::new(450000),
                     ),
-                    FeeDestination::new(
+                    FeeDestinationV2::new(
                         "tp1uqx5fcrx0nkcak52tt794p03d5tju62qfnwc52",
-                        Decimal::percent(30),
+                        Uint128::new(300000),
                     ),
                 ],
                 get_default_entity_detail().to_some(),

--- a/src/execute/update_asset_verifier.rs
+++ b/src/execute/update_asset_verifier.rs
@@ -238,7 +238,6 @@ mod tests {
                     "",
                     Uint128::zero(),
                     NHASH,
-                    Uint128::zero(),
                     vec![],
                     None,
                 ),
@@ -295,14 +294,7 @@ mod tests {
             mock_info(DEFAULT_ADMIN_ADDRESS, &[]),
             UpdateAssetVerifierV1::new(
                 DEFAULT_ASSET_TYPE,
-                VerifierDetailV2::new(
-                    "unknown-address-guy",
-                    Uint128::zero(),
-                    NHASH,
-                    Uint128::zero(),
-                    vec![],
-                    None,
-                ),
+                VerifierDetailV2::new("unknown-address-guy", Uint128::zero(), NHASH, vec![], None),
             ),
         )
         .unwrap_err();
@@ -331,7 +323,6 @@ mod tests {
             DEFAULT_VERIFIER_ADDRESS,
             Uint128::new(420),
             NHASH,
-            Uint128::new(420),
             vec![
                 FeeDestinationV2::new(
                     "tp1av6u8yp70mf4f62vx6mzf68pkhut4ets5k4sgx",

--- a/src/execute/update_asset_verifier.rs
+++ b/src/execute/update_asset_verifier.rs
@@ -1,7 +1,7 @@
 use crate::core::error::ContractError;
 use crate::core::msg::ExecuteMsg;
-use crate::core::state::{load_asset_definition_by_type, replace_asset_definition};
-use crate::core::types::verifier_detail::VerifierDetail;
+use crate::core::state::{load_asset_definition_v2_by_type, replace_asset_definition_v2};
+use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
 use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
 use crate::util::event_attributes::{EventAttributes, EventType};
@@ -14,29 +14,29 @@ use cosmwasm_std::{MessageInfo, Response};
 ///
 /// # Parameters
 ///
-/// * `asset_type` The unique identifier for the target [AssetDefinition](crate::core::types::asset_definition::AssetDefinition),
-/// keyed on its [asset_type](crate::core::types::asset_definition::AssetDefinition::asset_type)
-/// property that the target verifier detail lives in, in its [verifiers](crate::core::types::asset_definition::AssetDefinition::verifiers)
+/// * `asset_type` The unique identifier for the target [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2),
+/// keyed on its [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type)
+/// property that the target verifier detail lives in, in its [verifiers](crate::core::types::asset_definition::AssetDefinitionV2::verifiers)
 /// property.
 /// * `verifier` The verifier detail that will be updated.  All values within this provided struct
-/// will replace the existing detail on the target [AssetDefinition](crate::core::types::asset_definition::AssetDefinition).
+/// will replace the existing detail on the target [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2).
 #[derive(Clone, PartialEq)]
 pub struct UpdateAssetVerifierV1 {
     pub asset_type: String,
-    pub verifier: VerifierDetail,
+    pub verifier: VerifierDetailV2,
 }
 impl UpdateAssetVerifierV1 {
     /// Constructs a new instance of this struct.
     ///
     /// # Parameters
     ///
-    /// * `asset_type` The unique identifier for the target [AssetDefinition](crate::core::types::asset_definition::AssetDefinition),
-    /// keyed on its [asset_type](crate::core::types::asset_definition::AssetDefinition::asset_type)
-    /// property that the target verifier detail lives in, in its [verifiers](crate::core::types::asset_definition::AssetDefinition::verifiers)
+    /// * `asset_type` The unique identifier for the target [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2),
+    /// keyed on its [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type)
+    /// property that the target verifier detail lives in, in its [verifiers](crate::core::types::asset_definition::AssetDefinitionV2::verifiers)
     /// property.
     /// * `verifier` The verifier detail that will be updated.  All values within this provided struct
-    /// will replace the existing detail on the target [AssetDefinition](crate::core::types::asset_definition::AssetDefinition).
-    pub fn new<S: Into<String>>(asset_type: S, verifier: VerifierDetail) -> Self {
+    /// will replace the existing detail on the target [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2).
+    pub fn new<S: Into<String>>(asset_type: S, verifier: VerifierDetailV2) -> Self {
         UpdateAssetVerifierV1 {
             asset_type: asset_type.into(),
             verifier,
@@ -66,8 +66,8 @@ impl UpdateAssetVerifierV1 {
 }
 
 /// The function used by [execute](crate::contract::execute) when an [ExecuteMsg::UpdateAssetVerifier](crate::core::msg::ExecuteMsg::UpdateAssetVerifier)
-/// message is provided.  Replaces an existing [VerifierDetail](crate::core::types::verifier_detail::VerifierDetail)
-/// on an existing [AssetDefinition](crate::core::types::asset_definition::AssetDefinition).
+/// message is provided.  Replaces an existing [VerifierDetailV2](crate::core::types::verifier_detail::VerifierDetailV2)
+/// on an existing [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2).
 ///
 /// # Parameters
 ///
@@ -84,7 +84,7 @@ pub fn update_asset_verifier(
 ) -> EntryPointResponse {
     check_admin_only(&deps.as_ref(), &info)?;
     check_funds_are_empty(&info)?;
-    let mut asset_definition = load_asset_definition_by_type(deps.storage, &msg.asset_type)?;
+    let mut asset_definition = load_asset_definition_v2_by_type(deps.storage, &msg.asset_type)?;
     let verifier_address = msg.verifier.address.clone();
     // If a single verifier for the given address cannot be found, data is either corrupt, or the
     // verifier does not exist.  Given validation upfront prevents multiple verifiers with the
@@ -112,7 +112,7 @@ pub fn update_asset_verifier(
         replace_single_matching_vec_element(asset_definition.verifiers, msg.verifier, |v| {
             v.address == verifier_address
         })?;
-    replace_asset_definition(deps.storage, &asset_definition)?;
+    replace_asset_definition_v2(deps.storage, &asset_definition)?;
     // Respond with emitted attributes
     Response::new().add_attributes(attributes).to_ok()
 }
@@ -123,9 +123,9 @@ mod tests {
     use crate::contract::execute;
     use crate::core::error::ContractError;
     use crate::core::msg::ExecuteMsg;
-    use crate::core::state::load_asset_definition_by_type;
-    use crate::core::types::fee_destination::FeeDestination;
-    use crate::core::types::verifier_detail::VerifierDetail;
+    use crate::core::state::load_asset_definition_v2_by_type;
+    use crate::core::types::fee_destination::FeeDestinationV2;
+    use crate::core::types::verifier_detail::VerifierDetailV2;
     use crate::execute::update_asset_verifier::{update_asset_verifier, UpdateAssetVerifierV1};
     use crate::testutil::test_constants::{
         DEFAULT_ADMIN_ADDRESS, DEFAULT_ASSET_TYPE, DEFAULT_VERIFIER_ADDRESS,
@@ -142,7 +142,7 @@ mod tests {
     use crate::util::traits::OptionExtensions;
     use crate::validation::validate_init_msg::validate_verifier;
     use cosmwasm_std::testing::{mock_env, mock_info};
-    use cosmwasm_std::{coin, Decimal, Uint128};
+    use cosmwasm_std::{coin, Uint128};
     use provwasm_mocks::mock_dependencies;
 
     #[test]
@@ -233,12 +233,12 @@ mod tests {
             mock_info(DEFAULT_ADMIN_ADDRESS, &[]),
             ExecuteMsg::UpdateAssetVerifier {
                 asset_type: DEFAULT_ASSET_TYPE.to_string(),
-                verifier: VerifierDetail::new(
+                verifier: VerifierDetailV2::new(
                     // Invalid because the address is blank
                     "",
-                    Uint128::new(0),
+                    Uint128::zero(),
                     NHASH,
-                    Decimal::percent(0),
+                    Uint128::zero(),
                     vec![],
                     None,
                 ),
@@ -295,11 +295,11 @@ mod tests {
             mock_info(DEFAULT_ADMIN_ADDRESS, &[]),
             UpdateAssetVerifierV1::new(
                 DEFAULT_ASSET_TYPE,
-                VerifierDetail::new(
+                VerifierDetailV2::new(
                     "unknown-address-guy",
-                    Uint128::new(100),
+                    Uint128::zero(),
                     NHASH,
-                    Decimal::percent(0),
+                    Uint128::zero(),
                     vec![],
                     None,
                 ),
@@ -313,8 +313,8 @@ mod tests {
         );
     }
 
-    fn test_default_verifier_was_updated(verifier: &VerifierDetail, deps: &DepsC) {
-        let state_def = load_asset_definition_by_type(deps.storage, DEFAULT_ASSET_TYPE)
+    fn test_default_verifier_was_updated(verifier: &VerifierDetailV2, deps: &DepsC) {
+        let state_def = load_asset_definition_v2_by_type(deps.storage, DEFAULT_ASSET_TYPE)
             .expect("expected the default asset type to be stored in the state");
         let target_verifier = state_def.verifiers.into_iter().find(|v| v.address == verifier.address)
             .expect("expected a single verifier to be produced when searching for the updated verifier's address");
@@ -326,20 +326,20 @@ mod tests {
 
     // This builds off of the existing default asset verifier in test_utilities and adds/tweaks
     // details.  The fee addresses are randomly-generated bech32 provenance testnet addresses
-    fn get_valid_update_verifier() -> VerifierDetail {
-        let verifier = VerifierDetail::new(
+    fn get_valid_update_verifier() -> VerifierDetailV2 {
+        let verifier = VerifierDetailV2::new(
             DEFAULT_VERIFIER_ADDRESS,
             Uint128::new(420),
             NHASH,
-            Decimal::percent(100),
+            Uint128::new(420),
             vec![
-                FeeDestination::new(
+                FeeDestinationV2::new(
                     "tp1av6u8yp70mf4f62vx6mzf68pkhut4ets5k4sgx",
-                    Decimal::percent(50),
+                    Uint128::new(210),
                 ),
-                FeeDestination::new(
+                FeeDestinationV2::new(
                     "tp169qp36ax8gvtrzszfevqcwhe4hn2g02g35lne8",
-                    Decimal::percent(50),
+                    Uint128::new(210),
                 ),
             ],
             get_default_entity_detail().to_some(),

--- a/src/instantiate/init_contract.rs
+++ b/src/instantiate/init_contract.rs
@@ -165,7 +165,6 @@ mod tests {
                 DEFAULT_VERIFIER_ADDRESS,
                 DEFAULT_ONBOARDING_COST.into(),
                 DEFAULT_ONBOARDING_DENOM,
-                Uint128::new(DEFAULT_ONBOARDING_COST / 2),
                 vec![FeeDestinationV2::new(
                     "tp18c94z83e6ng2sc3ylvutzytlx8zqggm554xp5a",
                     Uint128::new(DEFAULT_ONBOARDING_COST / 2),
@@ -183,7 +182,6 @@ mod tests {
                 "tp1n6zl5u3x4k2uq29a5rxvh8g339wnk8j7v2sxdq",
                 Uint128::new(150),
                 NHASH,
-                Uint128::new(150),
                 vec![
                     FeeDestinationV2::new(
                         "tp18c94z83e6ng2sc3ylvutzytlx8zqggm554xp5a",

--- a/src/migrate/migrate_to_asset_definition_v2.rs
+++ b/src/migrate/migrate_to_asset_definition_v2.rs
@@ -1,0 +1,284 @@
+use crate::core::msg::MigrationOptions;
+use crate::core::state::{asset_definitions, insert_asset_definition_v2};
+use crate::core::types::asset_definition::AssetDefinitionV2;
+use crate::migrate::migrate_contract::migrate_contract;
+use crate::util::aliases::{DepsMutC, EntryPointResponse};
+use crate::util::traits::ResultExtensions;
+use cosmwasm_std::Order;
+
+pub fn migrate_to_asset_definition_v2(
+    deps: DepsMutC,
+    options: Option<MigrationOptions>,
+) -> EntryPointResponse {
+    let asset_definitions = asset_definitions()
+        .range_raw(deps.storage, None, None, Order::Descending)
+        .map(|item| item.unwrap().1.to_v2())
+        .collect::<Vec<AssetDefinitionV2>>();
+    let migrated_def_count = asset_definitions.len();
+    for definition in asset_definitions.into_iter() {
+        insert_asset_definition_v2(deps.storage, &definition)?;
+    }
+    // Pass through the existing migration code to ensure version upgrades also occur
+    migrate_contract(deps, options)?
+        .add_attribute("asset_definitions_migrated", migrated_def_count.to_string())
+        .to_ok()
+}
+
+#[cfg(test)]
+#[cfg(feature = "enable-test-utils")]
+mod tests {
+    use crate::contract::migrate;
+    use crate::core::msg::MigrateMsg;
+    use crate::core::state::{
+        asset_definitions, load_asset_definition_v2_by_scope_spec, load_asset_definition_v2_by_type,
+    };
+    use crate::core::types::asset_definition::AssetDefinition;
+    use crate::core::types::fee_destination::FeeDestination;
+    use crate::core::types::verifier_detail::VerifierDetail;
+    use crate::migrate::version_info::{set_version_info, VersionInfoV1, CONTRACT_NAME};
+    use crate::testutil::test_utilities::{
+        assert_single_item, assert_single_item_by, get_default_entity_detail,
+        single_attribute_for_key, test_instantiate_success, InstArgs, MockOwnedDeps,
+    };
+    use crate::util::traits::OptionExtensions;
+    use cosmwasm_std::testing::mock_env;
+    use cosmwasm_std::{Decimal, Uint128};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn test_migrate_without_asset_definitions() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test(&mut deps);
+        let response = migrate(
+            deps.as_mut(),
+            mock_env(),
+            MigrateMsg::MigrateToAssetDefinitionV2 { options: None },
+        )
+        .expect("expected the migration to run without issue");
+        assert!(
+            response.messages.is_empty(),
+            "expected no messages to be emitted by the migration"
+        );
+        assert_eq!(
+            3,
+            response.attributes.len(),
+            "expected the proper number of attributes to be emitted"
+        );
+        assert_eq!(
+            "0",
+            single_attribute_for_key(&response, "asset_definitions_migrated"),
+            "expected no asset definitions to be migrated because none existed in the contract state",
+        );
+    }
+
+    #[test]
+    fn test_migrate_with_asset_definitions() {
+        let mut deps = mock_dependencies(&[]);
+        setup_test(&mut deps);
+        // Insert a basic heloc asset definition with no fee destinations
+        asset_definitions()
+            .save(
+                deps.as_mut().storage,
+                "heloc".as_bytes(),
+                &AssetDefinition {
+                    asset_type: "heloc".to_string(),
+                    scope_spec_address: "heloc-scope-spec-address".to_string(),
+                    verifiers: vec![VerifierDetail {
+                        address: "heloc-verifier-address".to_string(),
+                        onboarding_cost: Uint128::new(100),
+                        onboarding_denom: "nhash".to_string(),
+                        fee_percent: Decimal::zero(),
+                        fee_destinations: vec![],
+                        entity_detail: get_default_entity_detail().to_some(),
+                    }],
+                    enabled: true,
+                },
+            )
+            .expect("expected the heloc asset definition to be added to storage");
+        // Insert a complex mortgage asset definition with fee destinations
+        asset_definitions()
+            .save(
+                deps.as_mut().storage,
+                "mortgage".as_bytes(),
+                &AssetDefinition {
+                    asset_type: "mortgage".to_string(),
+                    scope_spec_address: "mortgage-scope-spec-address".to_string(),
+                    verifiers: vec![VerifierDetail {
+                        address: "mortgage-verifier-address".to_string(),
+                        onboarding_cost: Uint128::new(500),
+                        onboarding_denom: "mortmoney".to_string(),
+                        fee_percent: Decimal::percent(50),
+                        fee_destinations: vec![
+                            FeeDestination {
+                                address: "fee-destination-1".to_string(),
+                                fee_percent: Decimal::percent(70),
+                            },
+                            FeeDestination {
+                                address: "fee-destination-2".to_string(),
+                                fee_percent: Decimal::percent(30),
+                            },
+                        ],
+                        entity_detail: None,
+                    }],
+                    enabled: false,
+                },
+            )
+            .expect("expected the mortgage asset definition to be added to storage");
+        let response = migrate(
+            deps.as_mut(),
+            mock_env(),
+            MigrateMsg::MigrateToAssetDefinitionV2 { options: None },
+        )
+        .expect("expected the migration to complete successfully");
+        assert!(
+            response.messages.is_empty(),
+            "expected no messages to be emitted by the migration"
+        );
+        assert_eq!(
+            3,
+            response.attributes.len(),
+            "expected the proper number of attributes to be emitted",
+        );
+        assert_eq!(
+            "2",
+            single_attribute_for_key(&response, "asset_definitions_migrated"),
+            "expected two asset definitions to be migrated because two were in contract storage",
+        );
+        load_asset_definition_v2_by_scope_spec(deps.as_ref().storage, "heloc-scope-spec-address")
+            .expect("expected the heloc definition to be able to load by scope spec address");
+        let heloc_definition = load_asset_definition_v2_by_type(deps.as_ref().storage, "heloc")
+            .expect("expected the heloc definition to exist in storage by type");
+        assert_eq!(
+            "heloc", heloc_definition.asset_type,
+            "expected the heloc asset type to be properly ported",
+        );
+        assert_eq!(
+            "heloc-scope-spec-address", heloc_definition.scope_spec_address,
+            "expected the heloc scope spec address to be properly ported",
+        );
+        assert!(
+            heloc_definition.enabled,
+            "expected the heloc enabled property to be properly ported",
+        );
+        let heloc_verifier = assert_single_item(
+            &heloc_definition.verifiers,
+            "expected the heloc definition to have a single verifier",
+        );
+        assert_eq!(
+            "heloc-verifier-address", heloc_verifier.address,
+            "expected the heloc verifier's address to be properly ported",
+        );
+        assert_eq!(
+            100,
+            heloc_verifier.onboarding_cost.u128(),
+            "expected the heloc verifier's onboarding cost to be properly ported",
+        );
+        assert_eq!(
+            "nhash", heloc_verifier.onboarding_denom,
+            "expected the heloc verifier's onboarding denom to be properly ported",
+        );
+        assert_eq!(
+            0,
+            heloc_verifier.fee_amount.u128(),
+            "expected the heloc verifier's fee amount to be properly derived",
+        );
+        assert!(
+            heloc_verifier.fee_destinations.is_empty(),
+            "expected no definitions to exist for the heloc verifier"
+        );
+        assert_eq!(
+            get_default_entity_detail(),
+            heloc_verifier
+                .entity_detail
+                .expect("expected the heloc verifier to have an entity detail"),
+            "expected the heloc verifier's entity detail to be properly ported",
+        );
+        load_asset_definition_v2_by_scope_spec(
+            deps.as_ref().storage,
+            "mortgage-scope-spec-address",
+        )
+        .expect("expected the mortgage definition to be able to load by scope spec address");
+        let mortgage_definition =
+            load_asset_definition_v2_by_type(deps.as_ref().storage, "mortgage")
+                .expect("expected the mortgage definition to exist in storage by type");
+        assert_eq!(
+            "mortgage", mortgage_definition.asset_type,
+            "expected the mortgage asset type to be properly ported",
+        );
+        assert_eq!(
+            "mortgage-scope-spec-address", mortgage_definition.scope_spec_address,
+            "expected the mortgage scope spec address to be properly ported",
+        );
+        assert_eq!(
+            false, mortgage_definition.enabled,
+            "expected the mortgage enabled property to be properly ported",
+        );
+        let mortgage_verifier = assert_single_item(
+            &mortgage_definition.verifiers,
+            "expected the mortgage definition to have a single verifier",
+        );
+        assert_eq!(
+            "mortgage-verifier-address", mortgage_verifier.address,
+            "expected the mortgage verifier's address to be properly ported",
+        );
+        assert_eq!(
+            500,
+            mortgage_verifier.onboarding_cost.u128(),
+            "expected the mortgage verifier's onboarding cost to be properly ported",
+        );
+        assert_eq!(
+            "mortmoney", mortgage_verifier.onboarding_denom,
+            "expected the mortgage verifier's onboarding denom to be properly ported",
+        );
+        assert_eq!(
+            250,
+            mortgage_verifier.fee_amount.u128(),
+            "expected the mortgage verifier's fee amount to be properly derived",
+        );
+        let fee_destination_1 = assert_single_item_by(
+            &mortgage_verifier.fee_destinations,
+            "expected a single fee destination to exist for the mortgage verifier with address 'fee-destination-1'",
+            |dest| dest.address == "fee-destination-1",
+        );
+        assert_eq!(
+            175,
+            fee_destination_1.fee_amount.u128(),
+            "expected the fee amount for the first fee destination to be properly derived",
+        );
+        assert!(
+            fee_destination_1.entity_detail.is_none(),
+            "expected no entity detail to be populated on a fresh port of a fee destination"
+        );
+        let fee_destination_2 = assert_single_item_by(
+            &mortgage_verifier.fee_destinations,
+            "expected a single fee destination to exist for the mortgage verifier with address 'fee-destination-2'",
+            |dest| dest.address == "fee-destination-2",
+        );
+        assert_eq!(
+            75,
+            fee_destination_2.fee_amount.u128(),
+            "expected the fee amount for the second fee destination to be properly derived",
+        );
+        assert!(
+            fee_destination_2.entity_detail.is_none(),
+            "expected no entity detail to be populated on a fresh port of a fee destination"
+        );
+        assert!(
+            mortgage_verifier.entity_detail.is_none(),
+            "expected the lack of entity detail on the mortgage verifier to be properly ported"
+        );
+    }
+
+    fn setup_test(deps: &mut MockOwnedDeps) {
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        // Downgrade the app version to ensure version collisions don't cause a rejected migration
+        set_version_info(
+            deps.as_mut().storage,
+            &VersionInfoV1 {
+                contract: CONTRACT_NAME.to_string(),
+                version: "0.0.0".to_string(),
+            },
+        )
+        .expect("expected the version number override to succeed");
+    }
+}

--- a/src/migrate/mod.rs
+++ b/src/migrate/mod.rs
@@ -2,6 +2,8 @@
 
 /// The main entrypoint function for running a code migration.  Referred to in the [contract file](crate::contract).
 pub mod migrate_contract;
+// TODO: Remove after removing AssetDefinitionV1
+pub mod migrate_to_asset_definition_v2;
 /// Module for structs and helper functions containing the version information stored for contract
 /// migrations.
 pub mod version_info;

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,9 +1,9 @@
 //! Contains the functionality used in the [contract file](crate::contract) to perform a contract query.
 
-/// A query that fetches a target [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+/// A query that fetches a target [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
 /// from the contract's internal storage.
 pub mod query_asset_definition;
-/// A query that fetches all [AssetDefinitions](crate::core::types::asset_definition::AssetDefinition)
+/// A query that fetches all [AssetDefinitionV2s](crate::core::types::asset_definition::AssetDefinitionV2)
 /// from the contract's internal storage.
 pub mod query_asset_definitions;
 /// A query that attempts to find an [AssetScopeAttribute](crate::core::types::asset_scope_attribute::AssetScopeAttribute)

--- a/src/query/query_asset_definition.rs
+++ b/src/query/query_asset_definition.rs
@@ -1,12 +1,12 @@
 use crate::core::state::{
-    may_load_asset_definition_by_scope_spec, may_load_asset_definition_by_type,
+    may_load_asset_definition_v2_by_scope_spec, may_load_asset_definition_v2_by_type,
 };
 use crate::core::types::asset_qualifier::AssetQualifier;
 use crate::util::aliases::{AssetResult, DepsC};
 use crate::util::traits::ResultExtensions;
 use cosmwasm_std::{to_binary, Binary};
 
-/// A query that fetches a target [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+/// A query that fetches a target [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
 /// from the contract's internal storage.
 ///
 /// # Parameters
@@ -14,14 +14,14 @@ use cosmwasm_std::{to_binary, Binary};
 /// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
 /// resources like contract internal storage and a querier to retrieve blockchain objects.
 /// * `qualifier` An enum containing identifier information that can be used to look up a stored
-/// [AssetDefinition](crate::core::types::asset_definition::AssetDefinition).
+/// [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2).
 pub fn query_asset_definition(deps: &DepsC, qualifier: AssetQualifier) -> AssetResult<Binary> {
     let asset_definition = match qualifier {
         AssetQualifier::AssetType(asset_type) => {
-            may_load_asset_definition_by_type(deps.storage, asset_type)
+            may_load_asset_definition_v2_by_type(deps.storage, asset_type)
         }
         AssetQualifier::ScopeSpecAddress(scope_spec_address) => {
-            may_load_asset_definition_by_scope_spec(deps.storage, scope_spec_address)
+            may_load_asset_definition_v2_by_scope_spec(deps.storage, scope_spec_address)
         }
     }?;
     to_binary(&asset_definition)?.to_ok()
@@ -30,8 +30,8 @@ pub fn query_asset_definition(deps: &DepsC, qualifier: AssetQualifier) -> AssetR
 #[cfg(test)]
 #[cfg(feature = "enable-test-utils")]
 mod tests {
-    use crate::core::state::insert_asset_definition;
-    use crate::core::types::asset_definition::AssetDefinition;
+    use crate::core::state::insert_asset_definition_v2;
+    use crate::core::types::asset_definition::{AssetDefinition, AssetDefinitionV2};
     use crate::core::types::asset_qualifier::AssetQualifier;
     use crate::query::query_asset_definition::query_asset_definition;
     use crate::testutil::test_utilities::{
@@ -77,7 +77,7 @@ mod tests {
     fn test_successful_query_from_direct_serialization_for_asset_type() {
         let mut deps = mock_dependencies(&[]);
         let asset_def = get_default_asset_definition();
-        insert_asset_definition(deps.as_mut().storage, &asset_def)
+        insert_asset_definition_v2(deps.as_mut().storage, &asset_def)
             .expect("expected the asset definition to be properly saved to state");
         let query_def = get_asset_from_query_by_asset_type(&deps.as_ref(), &asset_def.asset_type);
         assert_eq!(
@@ -90,7 +90,7 @@ mod tests {
     fn test_successful_query_from_direct_serialization_for_scope_spec() {
         let mut deps = mock_dependencies(&[]);
         let asset_def = get_default_asset_definition();
-        insert_asset_definition(deps.as_mut().storage, &asset_def)
+        insert_asset_definition_v2(deps.as_mut().storage, &asset_def)
             .expect("expected the asset definition to be properly saved to state");
         let query_def =
             get_asset_from_query_by_scope_spec(&deps.as_ref(), &asset_def.scope_spec_address);
@@ -133,11 +133,11 @@ mod tests {
     fn get_asset_from_query_by_asset_type<S: Into<String>>(
         deps: &DepsC,
         asset_type: S,
-    ) -> AssetDefinition {
+    ) -> AssetDefinitionV2 {
         let bin = query_asset_definition(deps, AssetQualifier::asset_type(asset_type)).expect(
             "the query should successfully serialize the value in storage as binary without error",
         );
-        from_binary::<Option<AssetDefinition>>(&bin)
+        from_binary::<Option<AssetDefinitionV2>>(&bin)
             .expect("binary deserialization should succeed")
             .expect("expected the deserialized option to be populated")
     }
@@ -145,7 +145,7 @@ mod tests {
     fn get_asset_from_query_by_scope_spec<S: Into<String>>(
         deps: &DepsC,
         scope_spec_address: S,
-    ) -> AssetDefinition {
+    ) -> AssetDefinitionV2 {
         let bin = query_asset_definition(
             deps,
             AssetQualifier::scope_spec_address(scope_spec_address),
@@ -153,7 +153,7 @@ mod tests {
         .expect(
             "the query should successfully serialize the value in storage as binary without error",
         );
-        from_binary::<Option<AssetDefinition>>(&bin)
+        from_binary::<Option<AssetDefinitionV2>>(&bin)
             .expect("binary deserialization should succeed")
             .expect("expected the deserialized option to be populated")
     }

--- a/src/query/query_asset_definitions.rs
+++ b/src/query/query_asset_definitions.rs
@@ -118,7 +118,6 @@ mod tests {
                         DEFAULT_VERIFIER_ADDRESS,
                         Uint128::new(150),
                         "nhash",
-                        Uint128::zero(),
                         vec![],
                         None,
                     )],

--- a/src/query/query_asset_scope_attribute.rs
+++ b/src/query/query_asset_scope_attribute.rs
@@ -1,10 +1,10 @@
 use cosmwasm_std::{to_binary, Addr, Binary};
 use provwasm_std::ProvenanceQuerier;
 
+use crate::core::state::load_asset_definition_v2_by_scope_spec;
 use crate::{
     core::{
         error::ContractError,
-        state::load_asset_definition_by_scope_spec,
         types::{asset_identifier::AssetIdentifier, asset_scope_attribute::AssetScopeAttribute},
     },
     util::{
@@ -120,7 +120,7 @@ pub fn may_query_scope_attribute_by_scope_address<S: Into<String>>(
     let scope = querier.get_scope(scope_address.into())?;
     // Second, query up the asset definition by the scope spec, which is a unique characteristic to the scope spec
     let asset_definition =
-        load_asset_definition_by_scope_spec(deps.storage, scope.specification_id)?;
+        load_asset_definition_v2_by_scope_spec(deps.storage, scope.specification_id)?;
     // Third, construct the attribute name that the scope attribute lives on by mixing the asset definition's asset type with state values
     let attribute_name = asset_definition.attribute_name(deps)?;
     // Fourth, query up scope attributes attached to the scope address under the name attribute.
@@ -149,10 +149,10 @@ mod tests {
     use cosmwasm_std::{from_binary, StdError};
     use provwasm_mocks::mock_dependencies;
 
+    use crate::core::state::load_asset_definition_v2_by_type;
     use crate::{
         core::{
             error::ContractError,
-            state::load_asset_definition_by_type,
             types::{
                 asset_identifier::AssetIdentifier, asset_scope_attribute::AssetScopeAttribute,
             },
@@ -179,7 +179,7 @@ mod tests {
         let scope_address = asset_uuid_to_scope_address(&asset_uuid)
             .expect("expected uuid to scope address conversion to work properly");
         // TDOO: Use the onboard_asset code here when it's ready with mock attribute tracking and such
-        let asset_def = load_asset_definition_by_type(deps.as_ref().storage, DEFAULT_ASSET_TYPE)
+        let asset_def = load_asset_definition_v2_by_type(deps.as_ref().storage, DEFAULT_ASSET_TYPE)
             .expect(
                 "the default asset definition should be available in storage after instantiation",
             );

--- a/src/service/asset_meta_service.rs
+++ b/src/service/asset_meta_service.rs
@@ -258,13 +258,15 @@ impl<'a> MessageGatheringService for AssetMetaService<'a> {
 #[cfg(test)]
 #[cfg(feature = "enable-test-utils")]
 mod tests {
-    use cosmwasm_std::{from_binary, to_binary, Addr, BankMsg, Coin, CosmosMsg, Decimal, Uint128};
+    use cosmwasm_std::{from_binary, to_binary, Addr, BankMsg, Coin, CosmosMsg, Uint128};
     use provwasm_mocks::mock_dependencies;
     use provwasm_std::{
         AttributeMsgParams, AttributeValueType, ProvenanceMsg, ProvenanceMsgParams,
     };
     use serde_json_wasm::to_string;
 
+    use crate::core::types::verifier_detail::VerifierDetailV2;
+    use crate::testutil::test_constants::DEFAULT_FEE_AMOUNT;
     use crate::{
         core::{
             error::ContractError,
@@ -276,7 +278,6 @@ mod tests {
                 asset_onboarding_status::AssetOnboardingStatus,
                 asset_scope_attribute::AssetScopeAttribute,
                 asset_verification_result::AssetVerificationResult,
-                verifier_detail::VerifierDetail,
             },
         },
         execute::verify_asset::VerifyAssetV1,
@@ -288,8 +289,8 @@ mod tests {
             onboard_asset_helpers::{test_onboard_asset, TestOnboardAsset},
             test_constants::{
                 DEFAULT_ASSET_TYPE, DEFAULT_ASSET_UUID, DEFAULT_CONTRACT_BASE_NAME,
-                DEFAULT_FEE_PERCENT, DEFAULT_ONBOARDING_COST, DEFAULT_ONBOARDING_DENOM,
-                DEFAULT_SCOPE_ADDRESS, DEFAULT_SENDER_ADDRESS, DEFAULT_VERIFIER_ADDRESS,
+                DEFAULT_ONBOARDING_COST, DEFAULT_ONBOARDING_DENOM, DEFAULT_SCOPE_ADDRESS,
+                DEFAULT_SENDER_ADDRESS, DEFAULT_VERIFIER_ADDRESS,
             },
             test_utilities::{
                 assert_single_item, get_default_access_routes, get_default_asset_scope_attribute,
@@ -560,11 +561,11 @@ mod tests {
                     requestor_address: Addr::unchecked(DEFAULT_SENDER_ADDRESS),
                     verifier_address: Addr::unchecked(DEFAULT_VERIFIER_ADDRESS),
                     onboarding_status: AssetOnboardingStatus::Pending,
-                    latest_verifier_detail: VerifierDetail {
+                    latest_verifier_detail: VerifierDetailV2 {
                         address: DEFAULT_VERIFIER_ADDRESS.to_string(),
                         onboarding_cost: Uint128::new(DEFAULT_ONBOARDING_COST),
                         onboarding_denom: DEFAULT_ONBOARDING_DENOM.to_string(),
-                        fee_percent: Decimal::percent(DEFAULT_FEE_PERCENT),
+                        fee_amount: Uint128::new(DEFAULT_FEE_AMOUNT),
                         fee_destinations: vec![],
                         entity_detail: get_default_entity_detail().to_some(),
                     }

--- a/src/service/asset_meta_service.rs
+++ b/src/service/asset_meta_service.rs
@@ -266,7 +266,6 @@ mod tests {
     use serde_json_wasm::to_string;
 
     use crate::core::types::verifier_detail::VerifierDetailV2;
-    use crate::testutil::test_constants::DEFAULT_FEE_AMOUNT;
     use crate::{
         core::{
             error::ContractError,
@@ -565,7 +564,6 @@ mod tests {
                         address: DEFAULT_VERIFIER_ADDRESS.to_string(),
                         onboarding_cost: Uint128::new(DEFAULT_ONBOARDING_COST),
                         onboarding_denom: DEFAULT_ONBOARDING_DENOM.to_string(),
-                        fee_amount: Uint128::new(DEFAULT_FEE_AMOUNT),
                         fee_destinations: vec![],
                         entity_detail: get_default_entity_detail().to_some(),
                     }

--- a/src/testutil/test_constants.rs
+++ b/src/testutil/test_constants.rs
@@ -22,8 +22,6 @@ pub const DEFAULT_SCOPE_SPEC_ADDRESS: &str = "scopespec1q323khk2jgw5hfada5ukdv3y
 pub const DEFAULT_ONBOARDING_COST: u128 = 1000;
 /// This is the default denom expected by the default verifier for onboarding
 pub const DEFAULT_ONBOARDING_DENOM: &str = NHASH;
-/// This is the default amount that is taken from the verifier to go to fees
-pub const DEFAULT_FEE_AMOUNT: u128 = 0;
 /// This is the default value that test_instantiate uses to create the contract's base name
 pub const DEFAULT_CONTRACT_BASE_NAME: &str = "asset";
 /// This is the default access route name to be set for the onboarding address

--- a/src/testutil/test_constants.rs
+++ b/src/testutil/test_constants.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_ONBOARDING_COST: u128 = 1000;
 /// This is the default denom expected by the default verifier for onboarding
 pub const DEFAULT_ONBOARDING_DENOM: &str = NHASH;
 /// This is the default amount that is taken from the verifier to go to fees
-pub const DEFAULT_FEE_PERCENT: u64 = 0;
+pub const DEFAULT_FEE_AMOUNT: u128 = 0;
 /// This is the default value that test_instantiate uses to create the contract's base name
 pub const DEFAULT_CONTRACT_BASE_NAME: &str = "asset";
 /// This is the default access route name to be set for the onboarding address

--- a/src/testutil/test_utilities.rs
+++ b/src/testutil/test_utilities.rs
@@ -1,7 +1,7 @@
 use cosmwasm_std::{
     from_binary,
     testing::{mock_env, mock_info, MockApi, MockStorage},
-    Addr, Coin, CosmosMsg, Decimal, Env, MessageInfo, OwnedDeps, Response, Uint128,
+    Addr, Coin, CosmosMsg, Env, MessageInfo, OwnedDeps, Response, Uint128,
 };
 use provwasm_mocks::ProvenanceMockQuerier;
 use provwasm_std::{
@@ -11,18 +11,19 @@ use provwasm_std::{
 };
 use serde_json_wasm::to_string;
 
+use crate::core::types::asset_definition::{AssetDefinitionInputV2, AssetDefinitionV2};
+use crate::core::types::verifier_detail::VerifierDetailV2;
+use crate::testutil::test_constants::DEFAULT_FEE_AMOUNT;
 use crate::{
     contract::instantiate,
     core::{
         msg::InitMsg,
         types::{
             access_definition::{AccessDefinition, AccessDefinitionType},
-            asset_definition::{AssetDefinition, AssetDefinitionInput},
             asset_onboarding_status::AssetOnboardingStatus,
             asset_scope_attribute::AssetScopeAttribute,
             entity_detail::EntityDetail,
             scope_spec_identifier::ScopeSpecIdentifier,
-            verifier_detail::VerifierDetail,
         },
     },
     util::{functions::generate_asset_attribute_name, traits::OptionExtensions},
@@ -36,18 +37,18 @@ use super::test_constants::{
     DEFAULT_ACCESS_ROUTE_NAME, DEFAULT_ACCESS_ROUTE_ROUTE, DEFAULT_ADMIN_ADDRESS,
     DEFAULT_ASSET_TYPE, DEFAULT_ASSET_UUID, DEFAULT_CONTRACT_BASE_NAME,
     DEFAULT_ENTITY_DETAIL_DESCRIPTION, DEFAULT_ENTITY_DETAIL_HOME_URL, DEFAULT_ENTITY_DETAIL_NAME,
-    DEFAULT_ENTITY_DETAIL_SOURCE_URL, DEFAULT_FEE_PERCENT, DEFAULT_ONBOARDING_COST,
-    DEFAULT_ONBOARDING_DENOM, DEFAULT_PROCESS_ADDRESS, DEFAULT_PROCESS_METHOD,
-    DEFAULT_PROCESS_NAME, DEFAULT_RECORD_INPUT_NAME, DEFAULT_RECORD_INPUT_SOURCE_ADDRESS,
-    DEFAULT_RECORD_NAME, DEFAULT_RECORD_OUTPUT_HASH, DEFAULT_RECORD_SPEC_ADDRESS,
-    DEFAULT_SCOPE_ADDRESS, DEFAULT_SCOPE_SPEC_ADDRESS, DEFAULT_SENDER_ADDRESS,
-    DEFAULT_SESSION_ADDRESS, DEFAULT_VERIFIER_ADDRESS,
+    DEFAULT_ENTITY_DETAIL_SOURCE_URL, DEFAULT_ONBOARDING_COST, DEFAULT_ONBOARDING_DENOM,
+    DEFAULT_PROCESS_ADDRESS, DEFAULT_PROCESS_METHOD, DEFAULT_PROCESS_NAME,
+    DEFAULT_RECORD_INPUT_NAME, DEFAULT_RECORD_INPUT_SOURCE_ADDRESS, DEFAULT_RECORD_NAME,
+    DEFAULT_RECORD_OUTPUT_HASH, DEFAULT_RECORD_SPEC_ADDRESS, DEFAULT_SCOPE_ADDRESS,
+    DEFAULT_SCOPE_SPEC_ADDRESS, DEFAULT_SENDER_ADDRESS, DEFAULT_SESSION_ADDRESS,
+    DEFAULT_VERIFIER_ADDRESS,
 };
 
 pub type MockOwnedDeps = OwnedDeps<MockStorage, MockApi, ProvenanceMockQuerier, ProvenanceQuery>;
 
-pub fn get_default_asset_definition_input() -> AssetDefinitionInput {
-    AssetDefinitionInput {
+pub fn get_default_asset_definition_input() -> AssetDefinitionInputV2 {
+    AssetDefinitionInputV2 {
         asset_type: DEFAULT_ASSET_TYPE.into(),
         scope_spec_identifier: ScopeSpecIdentifier::address(DEFAULT_SCOPE_SPEC_ADDRESS)
             .to_serialized_enum(),
@@ -68,28 +69,28 @@ pub fn get_default_entity_detail() -> EntityDetail {
     )
 }
 
-pub fn get_default_verifier_detail() -> VerifierDetail {
-    VerifierDetail {
+pub fn get_default_verifier_detail() -> VerifierDetailV2 {
+    VerifierDetailV2 {
         address: DEFAULT_VERIFIER_ADDRESS.into(),
         onboarding_cost: Uint128::from(DEFAULT_ONBOARDING_COST),
         onboarding_denom: DEFAULT_ONBOARDING_DENOM.into(),
-        fee_percent: Decimal::percent(DEFAULT_FEE_PERCENT),
+        fee_amount: Uint128::new(DEFAULT_FEE_AMOUNT),
         fee_destinations: vec![],
         entity_detail: get_default_entity_detail().to_some(),
     }
 }
 
-pub fn get_default_asset_definition() -> AssetDefinition {
+pub fn get_default_asset_definition() -> AssetDefinitionV2 {
     get_default_asset_definition_input()
         .into_asset_definition()
         .expect("the default asset definition input could not be parsed as an asset definition")
 }
 
-pub fn get_default_asset_definition_inputs() -> Vec<AssetDefinitionInput> {
+pub fn get_default_asset_definition_inputs() -> Vec<AssetDefinitionInputV2> {
     vec![get_default_asset_definition_input()]
 }
 
-pub fn get_default_asset_definitions() -> Vec<AssetDefinition> {
+pub fn get_default_asset_definitions() -> Vec<AssetDefinitionV2> {
     get_default_asset_definition_inputs()
         .into_iter()
         .map(|input| {
@@ -132,7 +133,7 @@ pub struct InstArgs {
     pub base_contract_name: String,
     pub bind_base_name: bool,
     pub is_test: bool,
-    pub asset_definitions: Vec<AssetDefinitionInput>,
+    pub asset_definitions: Vec<AssetDefinitionInputV2>,
 }
 impl Default for InstArgs {
     fn default() -> Self {

--- a/src/testutil/test_utilities.rs
+++ b/src/testutil/test_utilities.rs
@@ -13,7 +13,6 @@ use serde_json_wasm::to_string;
 
 use crate::core::types::asset_definition::{AssetDefinitionInputV2, AssetDefinitionV2};
 use crate::core::types::verifier_detail::VerifierDetailV2;
-use crate::testutil::test_constants::DEFAULT_FEE_AMOUNT;
 use crate::{
     contract::instantiate,
     core::{
@@ -74,7 +73,6 @@ pub fn get_default_verifier_detail() -> VerifierDetailV2 {
         address: DEFAULT_VERIFIER_ADDRESS.into(),
         onboarding_cost: Uint128::from(DEFAULT_ONBOARDING_COST),
         onboarding_denom: DEFAULT_ONBOARDING_DENOM.into(),
-        fee_amount: Uint128::new(DEFAULT_FEE_AMOUNT),
         fee_destinations: vec![],
         entity_detail: get_default_entity_detail().to_some(),
     }

--- a/src/testutil/test_utilities.rs
+++ b/src/testutil/test_utilities.rs
@@ -333,6 +333,16 @@ pub fn assert_single_item<T: Clone, S: Into<String>>(slice: &[T], message: S) ->
     slice.first().unwrap().clone()
 }
 
+pub fn assert_single_item_by<T: Clone, S: Into<String>, F: FnMut(&&T) -> bool>(
+    slice: &[T],
+    message: S,
+    predicate: F,
+) -> T {
+    let filtered_slice = slice.into_iter().filter(predicate).collect::<Vec<&T>>();
+    assert_eq!(1, filtered_slice.len(), "{}", message.into());
+    filtered_slice.first().unwrap().clone().to_owned()
+}
+
 /// Crawls the vector of messages contained in the provided response, and, if an add attribute message
 /// is contained therein, will set the attribute in the MockOwnedDeps' ProvenanceMockQuerier, which
 /// will cause downstream consumers in the rest of the test structure to see that attribute as the latest

--- a/src/util/event_attributes.rs
+++ b/src/util/event_attributes.rs
@@ -86,9 +86,9 @@ impl EventAttributes {
     /// * `event_type` All events should denote their type for external consumers of Provenance
     /// Blockchain Event Stream, so this value is required for any new instance and appends the
     /// name of the event with the key of [ASSET_EVENT_TYPE_KEY](super::constants::ASSET_EVENT_TYPE_KEY).
-    /// * `asset_type` A unique key for an [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+    /// * `asset_type` A unique key for an [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
     /// that uses the key [ASSET_TYPE_KEY](super::constants::ASSET_TYPE_KEY).
-    /// * `scope_address` A unique key for an [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+    /// * `scope_address` A unique key for an [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
     /// that uses the key [ASSET_SCOPE_ADDRESS_KEY](super::constants::ASSET_SCOPE_ADDRESS_KEY).
     pub fn for_asset_event<T1: Into<String>, T2: Into<String>>(
         event_type: EventType,
@@ -105,7 +105,7 @@ impl EventAttributes {
     ///
     /// # Parameters
     ///
-    /// * `asset_type` A unique key for an [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+    /// * `asset_type` A unique key for an [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
     /// that uses the key [ASSET_TYPE_KEY](super::constants::ASSET_TYPE_KEY).
     pub fn set_asset_type<T: Into<String>>(mut self, asset_type: T) -> Self {
         self.attributes
@@ -118,7 +118,7 @@ impl EventAttributes {
     ///
     /// # Parameters
     ///
-    /// * `scope_address` A unique key for an [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+    /// * `scope_address` A unique key for an [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
     /// that uses the key [ASSET_SCOPE_ADDRESS_KEY](super::constants::ASSET_SCOPE_ADDRESS_KEY).
     pub fn set_scope_address<T: Into<String>>(mut self, scope_address: T) -> Self {
         self.attributes
@@ -131,8 +131,8 @@ impl EventAttributes {
     ///
     /// # Parameters
     ///
-    /// * `verifier_address` The [address](crate::core::types::verifier_detail::VerifierDetail::address)
-    /// for a [VerifierDetail](crate::core::types::verifier_detail::VerifierDetail) that uses the
+    /// * `verifier_address` The [address](crate::core::types::verifier_detail::VerifierDetailV2::address)
+    /// for a [VerifierDetailV2](crate::core::types::verifier_detail::VerifierDetailV2) that uses the
     /// key [VERIFIER_ADDRESS_KEY](super::constants::VERIFIER_ADDRESS_KEY).
     pub fn set_verifier<T: Into<String>>(mut self, verifier_address: T) -> Self {
         self.attributes

--- a/src/util/functions.rs
+++ b/src/util/functions.rs
@@ -2,11 +2,10 @@ use crate::core::error::ContractError;
 use crate::core::types::access_route::AccessRoute;
 use crate::util::aliases::AssetResult;
 use crate::util::traits::ResultExtensions;
-use cosmwasm_std::{coin, BankMsg, CosmosMsg, Decimal, Uint128};
+use cosmwasm_std::{coin, BankMsg, CosmosMsg};
 use provwasm_std::ProvenanceMsg;
 use std::collections::HashSet;
 use std::hash::Hash;
-use std::ops::Mul;
 
 /// Determines how many elements within the provided reference slice are unique by the given
 /// property.
@@ -39,8 +38,8 @@ where
 /// # Parameters
 ///
 /// * `asset_type` The value to use at the beginning of the name qualifier.  Should refer to the
-/// [asset_type](crate::core::types::asset_definition::AssetDefinition::asset_type) property of an
-/// [AssetDefinition](crate::core::types::asset_definition::AssetDefinition).
+/// [asset_type](crate::core::types::asset_definition::AssetDefinitionV2::asset_type) property of an
+/// [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2).
 /// * `base_contract_name` The value to use at the end of the name qualifier, after the dot.  Should
 /// refer to the [base_contract_name](crate::core::state::StateV2::base_contract_name) of the
 /// contract's [StateV2](crate::core::state::StateV2) internally-stored value.
@@ -59,25 +58,6 @@ pub fn generate_asset_attribute_name<T: Into<String>, U: Into<String>>(
     base_contract_name: U,
 ) -> String {
     format!("{}.{}", asset_type.into(), base_contract_name.into())
-}
-
-/// Converts a decimal to a display string, like "1%".
-///
-/// # Parameters
-///
-/// * `decimal` The cosmwasm decimal instance to convert to a percent.
-///
-/// # Examples
-/// ```
-/// use cosmwasm_std::Decimal;
-/// use asset_classification_smart_contract::util::functions::decimal_display_string;
-///
-/// let decimal = Decimal::percent(25);
-/// let display_string = decimal_display_string(&decimal);
-/// assert_eq!("25%", display_string.as_str());
-/// ```
-pub fn decimal_display_string(decimal: &Decimal) -> String {
-    format!("{}%", Uint128::new(100).mul(*decimal))
 }
 
 /// Takes an existing vector, moves it into this function, swaps out a single existing item for

--- a/src/validation/mod.rs
+++ b/src/validation/mod.rs
@@ -3,5 +3,5 @@
 /// Validates the integrity of an intercepted [ExecuteMsg](crate::core::msg::ExecuteMsg) variant.
 pub mod validate_execute_msg;
 /// Validates the integrity of an intercepted [InitMsg](crate::core::msg::InitMsg) and its
-/// associated [AssetDefinition](crate::core::types::asset_definition::AssetDefinition) values.
+/// associated [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2) values.
 pub mod validate_init_msg;

--- a/src/validation/validate_execute_msg.rs
+++ b/src/validation/validate_execute_msg.rs
@@ -2,7 +2,7 @@ use crate::core::error::ContractError;
 use crate::core::msg::ExecuteMsg;
 use crate::core::types::asset_identifier::AssetIdentifier;
 use crate::core::types::serialized_enum::SerializedEnum;
-use crate::core::types::verifier_detail::VerifierDetail;
+use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::util::aliases::AssetResult;
 use crate::util::traits::{OptionExtensions, ResultExtensions};
 use crate::validation::validate_init_msg::{
@@ -59,10 +59,10 @@ pub fn validate_execute_msg(msg: &ExecuteMsg) -> AssetResult<()> {
 ///
 /// * `identifier` An [AssetIdentifier](crate::core::types::asset_identifier::AssetIdentifier)
 /// encapsulated within a [SerializedEnum](crate::core::types::serialized_enum::SerializedEnum).
-/// * `asset_type` The type of asset to onboard, which should refer to an [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+/// * `asset_type` The type of asset to onboard, which should refer to an [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
 /// stored internally in the contract.
-/// * `verifier_address` The bech32 address of a [VerifierDetail](crate::core::types::verifier_detail::VerifierDetail)
-/// held within the target [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+/// * `verifier_address` The bech32 address of a [VerifierDetailV2](crate::core::types::verifier_detail::VerifierDetailV2)
+/// held within the target [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
 /// for onboarding.
 fn validate_onboard_asset(
     identifier: &SerializedEnum,
@@ -106,7 +106,7 @@ fn validate_verify_asset(identifier: &SerializedEnum) -> AssetResult<()> {
 ///
 /// # Parameters
 ///
-/// * `asset_type` The type of asset to toggle, which should refer to an [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+/// * `asset_type` The type of asset to toggle, which should refer to an [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
 /// stored internally in the contract.
 fn validate_toggle_asset_definition(asset_type: &str) -> AssetResult<()> {
     let mut invalid_fields: Vec<String> = vec![];
@@ -123,10 +123,10 @@ fn validate_toggle_asset_definition(asset_type: &str) -> AssetResult<()> {
 ///
 /// # Parameters
 ///
-/// * `asset_type` The type of asset to add or update, which should refer to an [AssetDefinition](crate::core::types::asset_definition::AssetDefinition)
+/// * `asset_type` The type of asset to add or update, which should refer to an [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
 /// stored internally in the contract.
 /// * `verifier` The verifier detail to add or update.
-fn validate_asset_verifier_msg(asset_type: &str, verifier: &VerifierDetail) -> AssetResult<()> {
+fn validate_asset_verifier_msg(asset_type: &str, verifier: &VerifierDetailV2) -> AssetResult<()> {
     let errors = if asset_type.is_empty() {
         vec!["asset_type must not be empty".to_string()].to_some()
     } else {

--- a/src/validation/validate_init_msg.rs
+++ b/src/validation/validate_init_msg.rs
@@ -153,12 +153,7 @@ fn validate_verifier_internal(verifier: &VerifierDetailV2) -> Vec<String> {
         invalid_fields.push("verifier:onboarding_denom: must not be blank".to_string());
     }
     if !verifier.fee_destinations.is_empty()
-        && verifier
-            .fee_destinations
-            .iter()
-            .map(|d| d.fee_amount.u128())
-            .sum::<u128>()
-            > verifier.onboarding_cost.u128()
+        && verifier.get_fee_total() > verifier.onboarding_cost.u128()
     {
         invalid_fields.push(
             "verifier:fee_destinations:fee_amounts must sum to be less than or equal to the onboarding cost".to_string(),

--- a/src/validation/validate_init_msg.rs
+++ b/src/validation/validate_init_msg.rs
@@ -10,7 +10,7 @@ use crate::util::traits::ResultExtensions;
 use cosmwasm_std::Uint128;
 
 /// Validates the integrity of an intercepted [InitMsg](crate::core::msg::InitMsg) and its
-/// associated [AssetDefinition](crate::core::types::asset_definition::AssetDefinition) values.
+/// associated [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2) values.
 ///
 /// # Parameters
 ///


### PR DESCRIPTION
# Description
This change creates a new subset of structs that drive the contract's configuration: `AssetDefinitionV2`, `VerifierDetailV2`, and `FeeDestinationV2`.  This is primarily to change from using a `fee_percent` in the `VerifierDetail` to use a `fee_amount`.  The core distinction between these two is that the fee percentage would cut a percentage from the total onboarding cost in the verifier and use that value to send to the verifier and to any addresses specified in the `FeeDestination`s.  This can easily get confusing if you simply want to send like `1000nhash` to a specific fee destination.  So, this change makes the values explicit, and the validation verifies that the top-level `fee_amount` value on a `VerifierDetailV2` must be reflected as a total aggregate of all `FeeDestinationV2`s' `fee_amount` values, versus having the fee destinations specify a percentage of the percent.

# Problems
Any existing `AssetScopeAttribute` instances that have not yet been verified will have an orphaned `VerifierDetail` written to them.  Fortunately, this is only in test, so data corruption is not a primary concern.  If the contract was launched in our production environment (or anyone else's) an additional route to load a scope attribute, convert its latest verifier detail to a v2 version, and then re-write would be required.  Frankly, it would be awful.  So it's important that this change is made before this contract is officially launched.

# Features
- Contract version has been upgraded to `v1.0.3`
- New `AssetDefinitionV2`, `VerifierDetailV2` and `FeeDestinationV2` structs and their respective load/save functions have been added.
- Adds an optional `EntityDetail` for fee destinations, for additional transparency in declarations.
- A new migration has been added that runs the existing migration code as well as converts all `AssetDefinition` struct values in storage to `AssetDefinitionV2` values.
- Swapped the constant `DEFAULT_FEE_PERCENT` to be `DEFAULT_FEE_AMOUNT`
- Added new test function `assert_single_item_by` which allows a single value to be located from a slice by using a predicate.
- Reworked verifier validation to ensure all fee amounts in the fee destinations sum to the amount specified in the verifier
- Reworked verifier fee distribution messages to simply create messages equal to the specified amounts and then post-validate that all amounts used sum to the expected total
- Removed the now-unnecessary function `decimal_display_string`

# Remaining Work
- Update asset classification libs to match the new struct structures.
- PR for asset manager, service-asset-onboarding, and asset-classification-verifier to use the new lib.
- Migrate the testnet contract to use the new version.
- Merge outstanding PRs to sync up with the new contract return values.
- Upgrade this contract to `v1.0.4` that removes all the old `AssetDefinition`, `VerifierDetail` and `FeeDestination` structs.