### PR TITLE
Feature: Add the ability to delete asset definitions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "1.0.4"
+version = "1.0.5"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/README.md
+++ b/README.md
@@ -7,14 +7,11 @@ to verify the contents of the asset by granting permission to them.
 ## Status
 [![Latest Release][release-badge]][release-latest]
 [![Apache 2.0 License][license-badge]][license-url]
-[![LOC][loc-badge]][loc-report]
 
 [license-badge]: https://img.shields.io/github/license/provenance-io/asset-classification-smart-contract.svg
 [license-url]: https://github.com/provenance-io/asset-classification-smart-contract/blob/main/LICENSE
 [release-badge]: https://img.shields.io/github/tag/provenance-io/asset-classification-smart-contract.svg
 [release-latest]: https://github.com/provenance-io/asset-classification-smart-contract/releases/latest
-[loc-badge]: https://tokei.rs/b1/github/provenance-io/asset-classification-smart-contract
-[loc-report]: https://github.com/provenance-io/asset-classification-smart-contract
 
 ## Documentation
 
@@ -389,7 +386,7 @@ asset definition.
 
 * `asset_type`: This value will be the `asset_type` value stored in the added [AssetDefinitionV2](src/core/types/asset_definition.rs).
 
-##### Response Sample
+##### Request Sample
 ```json
 {
   "add_asset_definition": {
@@ -450,7 +447,7 @@ ensures that after the update, all scope specification addresses contained in as
 
 * `asset_type`: This value will be the `asset_type` value stored in the updated [AssetDefinitionV2](src/core/types/asset_definition.rs).
 
-##### Response Sample
+##### Request Sample
 ```json
 {
   "update_asset_definition": {
@@ -514,12 +511,51 @@ the asset definition is in the intended state during the execution of the route.
 
 * `asset_new_value`: This value will be the new status of the asset definition's `enabled` property, after the toggle occurs (true/false).
 
-##### Response Sample
+##### Request Sample
 ```json
 {
   "toggle_asset_definition": {
     "asset_type": "airplane",
     "expected_result": "false"
+  }
+}
+```
+
+#### [Delete Asset Definition](src/execute/delete_asset_definition.rs)
+__This route is only accessible to the contract's admin address.__ When an [AssetDefinitionV2](src/core/types/asset_definition.rs)
+is erroneously added with an incorrect asset type, the scope specification address is unable to be used, as it is
+another unique key of the asset definition.  This route facilitates the removal of bad data.
+
+__IMPORTANT__: If an asset definition is completely removed, all contract references to it will fail to function.  This
+can cause assets currently in the onboarding process for a deleted type to have failures when interactions occur with
+them.  This functionality should only be used for an unused type!
+
+##### Request Parameters
+
+* `qualifier`: A serialized version of an [AssetQualifier](src/core/types/asset_qualifier.rs) enum.  Indicates the asset
+type to delete.  The following json is an example of what this might look like in a request:
+```json
+{"qualifier": {"type": "asset_type", "value": "porcupine"}}
+```
+OR
+```json
+{"qualifier": {"type": "scope_spec_address", "value": "scopespec1qsvpxtxcmw63rmy5v9rnyg5kxmqsdvzfr5"}}
+```
+
+##### Emitted Attributes
+* `asset_event_type`: This value will always be populated as `delete_asset_definition`.
+
+* `asset_type`: This value will be populated with the [asset_type](src/core/types/asset_definition.rs) property of the
+deleted [asset definition](src/core/types/asset_definition.rs).
+
+##### Request Sample
+```json
+{
+  "delete_asset_definition": {
+    "qualifier": {
+      "type": "asset_type",
+      "value": "widget"
+    }
   }
 }
 ```
@@ -547,7 +583,7 @@ parameter, or the request will be rejected.
 
 * `asset_verifier_address`: This value will be the bech32 address stored in the `address` property of the new [VerifierDetailV2](src/core/types/verifier_detail.rs).
 
-##### Response Sample
+##### Request Sample
 ```json
 {
   "add_asset_verifier": {
@@ -602,7 +638,7 @@ be rejected.
 
 * `asset_verifier_address`: This value will be the bech32 address stored in the `address` property of the updated [VerifierDetailV2](src/core/types/verifier_detail.rs).
 
-##### Response Sample
+##### Request Sample
 ```json
 {
   "update_asset_verifier": {
@@ -656,7 +692,7 @@ routes need to be included in the request alongside the new route(s).
 * `asset_scope_address`: This value will be the bech32 address of the [Provenance Blockchain Metadata Scope](https://docs.provenance.io/modules/metadata-module#metadata-scope)
 referred to by the `identifier` parameter passed into the execution message.
 
-__Full Request Sample__:
+##### Request Sample
 ```json
 {
   "update_access_routes": {

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -298,6 +298,32 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "description": "__This route is only accessible to the contract's admin address.__ When an [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2) is erroneously added with an incorrect asset type, the scope specification address is unable to be used, as it is another unique key of the asset definition.  This route facilitates the removal of bad data. IMPORTANT: If an asset definition is completely removed, all contract references to it will fail to function.  This can cause assets currently in the onboarding process for a deleted type to have failures when interactions occur with them.  This functionality should only be used for an unused type!",
+      "type": "object",
+      "required": [
+        "delete_asset_definition"
+      ],
+      "properties": {
+        "delete_asset_definition": {
+          "type": "object",
+          "required": [
+            "qualifier"
+          ],
+          "properties": {
+            "qualifier": {
+              "description": "Expects an [AssetQualifier](super::types::asset_qualifier::AssetQualifier)-compatible [SerializedEnum](super::types::serialized_enum::SerializedEnum) that will map to an existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).",
+              "allOf": [
+                {
+                  "$ref": "#/definitions/SerializedEnum"
+                }
+              ]
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -2,6 +2,7 @@ use crate::core::msg::{ExecuteMsg, InitMsg, MigrateMsg, QueryMsg};
 use crate::execute::add_asset_definition::{add_asset_definition, AddAssetDefinitionV1};
 use crate::execute::add_asset_verifier::{add_asset_verifier, AddAssetVerifierV1};
 use crate::execute::bind_contract_alias::{bind_contract_alias, BindContractAliasV1};
+use crate::execute::delete_asset_definition::{delete_asset_definition, DeleteAssetDefinitionV1};
 use crate::execute::onboard_asset::{onboard_asset, OnboardAssetV1};
 use crate::execute::toggle_asset_definition::{toggle_asset_definition, ToggleAssetDefinitionV1};
 use crate::execute::update_access_routes::{update_access_routes, UpdateAccessRoutesV1};
@@ -131,6 +132,9 @@ pub fn execute(deps: DepsMutC, env: Env, info: MessageInfo, msg: ExecuteMsg) -> 
         ),
         ExecuteMsg::BindContractAlias { .. } => {
             bind_contract_alias(deps, env, info, BindContractAliasV1::from_execute_msg(msg)?)
+        }
+        ExecuteMsg::DeleteAssetDefinition { .. } => {
+            delete_asset_definition(deps, info, DeleteAssetDefinitionV1::from_execute_msg(msg)?)
         }
     }
 }

--- a/src/core/msg.rs
+++ b/src/core/msg.rs
@@ -225,6 +225,20 @@ pub enum ExecuteMsg {
         /// The name to bind to the contract.  Ex: `assetclassificationalias.pb`.
         alias_name: String,
     },
+    /// __This route is only accessible to the contract's admin address.__ When an [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2)
+    /// is erroneously added with an incorrect asset type, the scope specification address is unable
+    /// to be used, as it is another unique key of the asset definition.  This route facilitates the
+    /// removal of bad data.
+    /// IMPORTANT: If an asset definition is completely removed, all contract references to it will
+    /// fail to function.  This can cause assets currently in the onboarding process for a deleted
+    /// type to have failures when interactions occur with them.  This functionality should only be
+    /// used for an unused type!
+    DeleteAssetDefinition {
+        /// Expects an [AssetQualifier](super::types::asset_qualifier::AssetQualifier)-compatible
+        /// [SerializedEnum](super::types::serialized_enum::SerializedEnum) that will map to an
+        /// existing [AssetDefinitionV2](super::types::asset_definition::AssetDefinitionV2).
+        qualifier: SerializedEnum,
+    },
 }
 
 /// The struct used to migrate the contract from one code instance to another.  Utilized in the core

--- a/src/execute/bind_contract_alias.rs
+++ b/src/execute/bind_contract_alias.rs
@@ -52,7 +52,7 @@ impl BindContractAliasV1 {
     }
 }
 
-/// Route implementation for ExecuteMsg::BindContractAlias.
+/// Route implementation for [ExecuteMsg::BindContractAlias](crate::core::msg::ExecuteMsg::BindContractAlias).
 /// This function allows the contract to bind a name to itself using the admin address.
 /// Note: Due to the way Provenance names work, this route will only work when attempting to self-bind
 /// to an unrestricted parent name.  Binding an alias to a restricted parent name will still require

--- a/src/execute/delete_asset_definition.rs
+++ b/src/execute/delete_asset_definition.rs
@@ -1,0 +1,296 @@
+use crate::core::error::ContractError;
+use crate::core::msg::ExecuteMsg;
+use crate::core::state::{
+    delete_asset_definition_v2_by_scope_spec_address, delete_asset_definition_v2_by_type,
+};
+use crate::core::types::asset_qualifier::AssetQualifier;
+use crate::util::aliases::{AssetResult, DepsMutC, EntryPointResponse};
+use crate::util::contract_helpers::{check_admin_only, check_funds_are_empty};
+use crate::util::event_attributes::{EventAdditionalMetadata, EventAttributes, EventType};
+use crate::util::traits::ResultExtensions;
+use cosmwasm_std::{MessageInfo, Response};
+
+/// A transformation of [ExecuteMsg::DeleteAssetDefinition](crate::core::msg::ExecuteMsg::DeleteAssetDefinition)
+/// for ease of use in the underlying [delete_asset_definition](self::delete_asset_definition) function.
+///
+/// # Parameters
+///
+/// * `qualifier` An asset qualifier that can identify the [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
+/// to delete.
+pub struct DeleteAssetDefinitionV1 {
+    pub qualifier: AssetQualifier,
+}
+impl DeleteAssetDefinitionV1 {
+    /// Constructs a new instance of this struct.
+    ///
+    /// # Parameters
+    ///
+    /// * `qualifier` An asset qualifier that can identify the [AssetDefinitionV2](crate::core::types::asset_definition::AssetDefinitionV2)
+    /// to delete.
+    pub fn new(qualifier: AssetQualifier) -> Self {
+        Self { qualifier }
+    }
+
+    /// Attempts to create an instance of this struct from a provided execute msg.  If the provided
+    /// value is not of the [DeleteAssetDefinition](crate::core::msg::ExecuteMsg::DeleteAssetDefinition)
+    /// variant, then an [InvalidMessageType](crate::core::error::ContractError::InvalidMessageType)
+    /// error will be returned.
+    ///
+    /// # Parameters
+    ///
+    /// * `msg` An execute msg provided by the contract's [execute](crate::contract::execute) function.
+    pub fn from_execute_msg(msg: ExecuteMsg) -> AssetResult<DeleteAssetDefinitionV1> {
+        match msg {
+            ExecuteMsg::DeleteAssetDefinition { qualifier } => {
+                DeleteAssetDefinitionV1::new(qualifier.to_asset_qualifier()?).to_ok()
+            }
+            _ => ContractError::InvalidMessageType {
+                expected_message_type: "ExecuteMsg::DeleteAssetDefinition".to_string(),
+            }
+            .to_err(),
+        }
+    }
+}
+
+/// Route implementation for [ExecuteMsg::DeleteAssetDefinition](crate::core::msg::ExecuteMsg::DeleteAssetDefinition).
+/// This function allows for the admin address to completely remove an asset definition.  This is
+/// dangerous, because existing assets in the onboarding process for an asset definition will start
+/// emitting errors when being verified or retried.  This should only ever be used on a definition
+/// that is guaranteed to be not in use and/or was erroneously added.
+///
+/// # Parameters
+///
+/// * `deps` A dependencies object provided by the cosmwasm framework.  Allows access to useful
+/// resources like contract internal storage and a querier to retrieve blockchain objects.
+/// * `info` A message information object provided by the cosmwasm framework.  Describes the sender
+/// of the instantiation message, as well as the funds provided as an amount during the transaction.
+/// * `msg` An instance of the delete asset definition v1 struct, provided by conversion from an
+/// [ExecuteMsg](crate::core::msg::ExecuteMsg).
+pub fn delete_asset_definition(
+    deps: DepsMutC,
+    info: MessageInfo,
+    msg: DeleteAssetDefinitionV1,
+) -> EntryPointResponse {
+    check_admin_only(&deps.as_ref(), &info)?;
+    check_funds_are_empty(&info)?;
+    let mut metadata = EventAdditionalMetadata::new();
+    match msg.qualifier {
+        AssetQualifier::AssetType(asset_type) => {
+            delete_asset_definition_v2_by_type(deps.storage, &asset_type)?;
+            metadata.add_metadata("asset_deleted_definition_asset_type", asset_type);
+        }
+        AssetQualifier::ScopeSpecAddress(scope_spec_address) => {
+            delete_asset_definition_v2_by_scope_spec_address(deps.storage, &scope_spec_address)?;
+            metadata.add_metadata(
+                "asset_deleted_definition_scope_spec_address",
+                scope_spec_address,
+            );
+        }
+    };
+    Response::new()
+        .add_attributes(
+            EventAttributes::new(EventType::DeleteAssetDefinition)
+                .set_additional_metadata(&metadata),
+        )
+        .to_ok()
+}
+
+#[cfg(test)]
+#[cfg(feature = "enable-test-utils")]
+mod tests {
+    use crate::contract::execute;
+    use crate::core::error::ContractError;
+    use crate::core::msg::ExecuteMsg;
+    use crate::core::state::{
+        load_asset_definition_v2_by_scope_spec, load_asset_definition_v2_by_type,
+    };
+    use crate::core::types::asset_qualifier::AssetQualifier;
+    use crate::execute::delete_asset_definition::{
+        delete_asset_definition, DeleteAssetDefinitionV1,
+    };
+    use crate::testutil::test_constants::{
+        DEFAULT_ADMIN_ADDRESS, DEFAULT_ASSET_TYPE, DEFAULT_SCOPE_SPEC_ADDRESS,
+    };
+    use crate::testutil::test_utilities::{
+        empty_mock_info, mock_info_with_funds, single_attribute_for_key, test_instantiate_success,
+        InstArgs,
+    };
+    use crate::util::constants::{ADDITIONAL_METADATA_KEY, ASSET_EVENT_TYPE_KEY};
+    use crate::util::event_attributes::EventType;
+    use cosmwasm_std::coin;
+    use cosmwasm_std::testing::mock_env;
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    fn test_delete_asset_definition_success_for_asset_type() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        load_asset_definition_v2_by_type(deps.as_ref().storage, DEFAULT_ASSET_TYPE).expect(
+            "sanity check: expected the default asset type to be inserted after instantiation",
+        );
+        let response = delete_asset_definition(
+            deps.as_mut(),
+            empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+            DeleteAssetDefinitionV1::new(AssetQualifier::asset_type(DEFAULT_ASSET_TYPE)),
+        )
+        .expect("expected deletion by asset type to succeed");
+        assert!(
+            response.messages.is_empty(),
+            "the route should not emit messages",
+        );
+        assert_eq!(
+            2,
+            response.attributes.len(),
+            "expected the correct number of attributes to be emitted",
+        );
+        assert_eq!(
+            EventType::DeleteAssetDefinition.event_name(),
+            single_attribute_for_key(&response, ASSET_EVENT_TYPE_KEY),
+            "expected the event type attribute to be set correctly",
+        );
+        assert_eq!(
+            format!("[asset_deleted_definition_asset_type={DEFAULT_ASSET_TYPE}]"),
+            single_attribute_for_key(&response, ADDITIONAL_METADATA_KEY),
+            "expected the additional metadata attribute to be set correctly",
+        );
+        let err = load_asset_definition_v2_by_type(deps.as_ref().storage, DEFAULT_ASSET_TYPE)
+            .expect_err("expected an error to occur when loading the default asset definition");
+        assert!(
+            matches!(err, ContractError::RecordNotFound { .. }),
+            "expected the record not found error to occur when attempting to access the asset definition after deletion, but got: {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn test_delete_asset_definition_success_for_scope_spec_address() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        load_asset_definition_v2_by_scope_spec(deps.as_ref().storage, DEFAULT_SCOPE_SPEC_ADDRESS).expect(
+            "sanity check: expected the default scope spec address's asset definition to be inserted after instantiation",
+        );
+        let response = delete_asset_definition(
+            deps.as_mut(),
+            empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+            DeleteAssetDefinitionV1::new(AssetQualifier::scope_spec_address(
+                DEFAULT_SCOPE_SPEC_ADDRESS,
+            )),
+        )
+        .expect("expected deletion by scope spec address to succeed");
+        assert!(
+            response.messages.is_empty(),
+            "the route should not emit messages",
+        );
+        assert_eq!(
+            2,
+            response.attributes.len(),
+            "expected the correct number of attributes to be emitted",
+        );
+        assert_eq!(
+            EventType::DeleteAssetDefinition.event_name(),
+            single_attribute_for_key(&response, ASSET_EVENT_TYPE_KEY),
+            "expected the event type attribute to be set correctly",
+        );
+        assert_eq!(
+            format!("[asset_deleted_definition_scope_spec_address={DEFAULT_SCOPE_SPEC_ADDRESS}]"),
+            single_attribute_for_key(&response, ADDITIONAL_METADATA_KEY),
+            "expected the additional metadata attribute to be set correctly",
+        );
+        let err = load_asset_definition_v2_by_scope_spec(
+            deps.as_ref().storage,
+            DEFAULT_SCOPE_SPEC_ADDRESS,
+        )
+        .expect_err("expected an error to occur when loading the default asset definition");
+        assert!(
+            matches!(err, ContractError::RecordNotFound { .. }),
+            "expected the record not found error to occur when attempting to access the asset definition after deletion, but got: {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn test_delete_asset_definition_success_from_execute_route() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        execute(
+            deps.as_mut(),
+            mock_env(),
+            empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+            ExecuteMsg::DeleteAssetDefinition {
+                qualifier: AssetQualifier::asset_type(DEFAULT_ASSET_TYPE).to_serialized_enum(),
+            },
+        )
+        .expect("expected the deletion to be successful");
+        let err = load_asset_definition_v2_by_type(deps.as_ref().storage, DEFAULT_ASSET_TYPE)
+            .expect_err("expected an error to occur when loading the default asset definition");
+        assert!(
+            matches!(err, ContractError::RecordNotFound { .. }),
+            "expected the record not found error to occur when attempting to access the asset definition after deletion, but got: {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn test_delete_asset_definition_failure_for_invalid_sender() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        let err = delete_asset_definition(
+            deps.as_mut(),
+            empty_mock_info("bad-actor"),
+            DeleteAssetDefinitionV1::new(AssetQualifier::asset_type(DEFAULT_ASSET_TYPE)),
+        )
+        .expect_err(
+            "expected an error to occur when a non-admin user attempts to access the route",
+        );
+        assert!(
+            matches!(err, ContractError::Unauthorized { .. }),
+            "expected an unauthorized error to be emitted, but got: {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn test_delete_asset_definition_failure_for_provided_funds() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        let err = delete_asset_definition(
+            deps.as_mut(),
+            mock_info_with_funds(DEFAULT_ADMIN_ADDRESS, &[coin(100, "coindollars")]),
+            DeleteAssetDefinitionV1::new(AssetQualifier::asset_type(DEFAULT_ADMIN_ADDRESS)),
+        )
+        .expect_err("expected an error to occur when funds are provided by the admin");
+        assert!(
+            matches!(err, ContractError::InvalidFunds(..)),
+            "expected an invalid funds error to be emitted, but got: {:?}",
+            err,
+        );
+    }
+
+    #[test]
+    fn test_delete_asset_definition_failure_for_missing_definition() {
+        let mut deps = mock_dependencies(&[]);
+        test_instantiate_success(deps.as_mut(), InstArgs::default());
+        let err = delete_asset_definition(
+            deps.as_mut(),
+            empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+            DeleteAssetDefinitionV1::new(AssetQualifier::asset_type("not real asset type")),
+        )
+        .expect_err("expected an error to occur when an invalid asset type is provided");
+        assert!(
+            matches!(err, ContractError::RecordNotFound { .. }),
+            "expected a record not found error to be emitted when deleting a missing asset type, but got: {:?}",
+            err,
+        );
+        let err = delete_asset_definition(
+            deps.as_mut(),
+            empty_mock_info(DEFAULT_ADMIN_ADDRESS),
+            DeleteAssetDefinitionV1::new(AssetQualifier::scope_spec_address("not real scope spec")),
+        )
+        .expect_err("expected an error to occur when an invalid scope spec address is provided");
+        assert!(
+            matches!(err, ContractError::RecordNotFound { .. }),
+            "expected a record not found error to be emitted when deleting a missing scope spec address, but got: {:?}",
+            err,
+        )
+    }
+}

--- a/src/execute/mod.rs
+++ b/src/execute/mod.rs
@@ -12,6 +12,10 @@ pub mod add_asset_verifier;
 /// [ExecuteMsg](crate::core::msg::ExecuteMsg) variant when invoked via the [execute](crate::contract::execute)
 /// function.
 pub mod bind_contract_alias;
+/// Contains the functionality used by the [DeleteAssetDefinition](crate::core::msg::ExecuteMsg::DeleteAssetDefinition)
+/// [ExecuteMsg](crate::core::msg::ExecuteMsg) variant when invoked via the [execute](crate::contract::execute)
+/// function.
+pub mod delete_asset_definition;
 /// Contains the functionality used by the [OnboardAsset](crate::core::msg::ExecuteMsg::OnboardAsset)
 /// [ExecuteMsg](crate::core::msg::ExecuteMsg) variant when invoked via the [execute](crate::contract::execute)
 /// function.

--- a/src/util/event_attributes.rs
+++ b/src/util/event_attributes.rs
@@ -30,6 +30,8 @@ pub enum EventType {
     UpdateAccessRoutes,
     /// Occurs when the contract is [executed](crate::contract::execute) to [bind a contract alias](crate::execute::bind_contract_alias).
     BindContractAlias,
+    /// Occurs when the contract is [executed](crate::contract::execute) to [delete an asset definition](crate::execute::delete_asset_definition).
+    DeleteAssetDefinition,
 }
 #[allow(clippy::from_over_into)]
 impl Into<String> for EventType {
@@ -46,6 +48,7 @@ impl Into<String> for EventType {
             EventType::UpdateAssetVerifier => "update_asset_verifier",
             EventType::UpdateAccessRoutes => "update_access_routes",
             EventType::BindContractAlias => "bind_contract_alias",
+            EventType::DeleteAssetDefinition => "delete_asset_definition",
         }
         .into()
     }


### PR DESCRIPTION
# Description
The `AssetDefinitionV2` struct currently lacks a positive way of being removed.  They can be disabled, but truly bad data should be purged.  This new execution route allows the admin to achieve that.

# Features
- Bump contract version to `v1.0.5`
- Add new readme documentation for the new route and fix some typos/mistakes in the initial incarnation.
- Add the ability to delete an asset definition by `AssetQualifier`
- Add the new execution route, `DeleteAssetDefinition`