### PR TITLE
v1.0.6: Remove latest verifier detail from asset scope attribute writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "asset-classification-smart-contract"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "bech32",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "asset-classification-smart-contract"
-version = "1.0.5"
+version = "1.0.6"
 authors = [
   "Jake Schwartz <jschwartz@figure.com>",
   "Pierce Trey <ptrey@figure.com>",

--- a/schema/asset_scope_attribute.json
+++ b/schema/asset_scope_attribute.json
@@ -40,7 +40,7 @@
       ]
     },
     "latest_verifier_detail": {
-      "description": "When the onboarding process runs, the verifier detail currently in contract storage for the verifier address chosen by the requestor is added to the scope attribute.  This ensures that if the verifier values change due to an external update, the original fee structure will be honored for the onboarding task placed originally.",
+      "description": "When the onboarding process runs, the verifier detail currently in contract storage for the verifier address chosen by the requestor is added to the scope attribute.  This ensures that if the verifier values change due to an external update, the original fee structure will be honored for the onboarding task placed originally.  This value should never be accessed directly in the contract, and instead the [get_latest_verifier_detail](self::AssetScopeAttribute::get_latest_verifier_detail) function should be used.  This field only exists in order for this value to be reflected accurately during queries.",
       "anyOf": [
         {
           "$ref": "#/definitions/VerifierDetailV2"

--- a/src/core/state.rs
+++ b/src/core/state.rs
@@ -351,7 +351,7 @@ pub fn insert_latest_verifier_detail<S: Into<String>>(
 ) -> AssetResult<()> {
     latest_verifier_detail_store(storage)
         .save(scope_address.into().as_bytes(), verifier_detail)
-        .map_err(|err| ContractError::Std(err))
+        .map_err(ContractError::Std)
 }
 
 /// Deletes an existing [VerifierDetailV2](crate::core::types::verifier_detail::VerifierDetailV2)
@@ -370,9 +370,8 @@ pub fn delete_latest_verifier_detail<S: Into<String>>(
     storage: &mut dyn Storage,
     scope_address: S,
 ) -> AssetResult<()> {
-    latest_verifier_detail_store(storage)
-        .remove(scope_address.into().as_bytes())
-        .to_ok()
+    latest_verifier_detail_store(storage).remove(scope_address.into().as_bytes());
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/service/asset_meta_repository.rs
+++ b/src/service/asset_meta_repository.rs
@@ -1,3 +1,4 @@
+use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::{
     core::types::{access_route::AccessRoute, asset_scope_attribute::AssetScopeAttribute},
     util::aliases::AssetResult,
@@ -21,9 +22,17 @@ pub trait AssetMetaRepository {
     ///
     /// * `attribute` The scope attribute to be appended to the Provenance Metadata Scope as a result
     /// of a successful onboarding process.
+    /// * `latest_verifier_detail` The verifier detail currently in storage when this scope is
+    /// onboarded.  Stored in contract storage until a verification has been completed to ensure that
+    /// the proper fee distribution is made when verification completes.
     /// * `is_retry` Indicates that this onboarding action was attempted before, and the scope has
     /// an existing scope attribute with a failed verification on it.
-    fn onboard_asset(&self, attribute: &AssetScopeAttribute, is_retry: bool) -> AssetResult<()>;
+    fn onboard_asset(
+        &self,
+        attribute: &AssetScopeAttribute,
+        latest_verifier_detail: &VerifierDetailV2,
+        is_retry: bool,
+    ) -> AssetResult<()>;
 
     /// Alters the internal values of the [AssetScopeAttribute](crate::core::types::asset_scope_attribute::AssetScopeAttribute)
     /// currently attached to a Provenance Metadata Scope with the provided values.

--- a/src/service/asset_meta_service.rs
+++ b/src/service/asset_meta_service.rs
@@ -3,6 +3,8 @@ use std::collections::HashSet;
 use cosmwasm_std::CosmosMsg;
 use provwasm_std::{delete_attributes, ProvenanceMsg};
 
+use crate::core::state::{delete_latest_verifier_detail, insert_latest_verifier_detail};
+use crate::core::types::verifier_detail::VerifierDetailV2;
 use crate::{
     core::{
         error::ContractError,
@@ -67,7 +69,12 @@ impl<'a> AssetMetaRepository for AssetMetaService<'a> {
         .to_ok()
     }
 
-    fn onboard_asset(&self, attribute: &AssetScopeAttribute, is_retry: bool) -> AssetResult<()> {
+    fn onboard_asset(
+        &self,
+        attribute: &AssetScopeAttribute,
+        latest_verifier_detail: &VerifierDetailV2,
+        is_retry: bool,
+    ) -> AssetResult<()> {
         // Verify that the attribute does or does not exist.  This check verifies that the value equivalent to is_retry:
         // If the asset exists, this should be a retry, because a subsequent onboard should only occur for that purpose
         // If the asset does not exist, this should not be a retry, because this is the first time the attribute is being attempted
@@ -96,6 +103,16 @@ impl<'a> AssetMetaRepository for AssetMetaService<'a> {
                 contract_base_name,
             )?);
         }
+
+        // Store the latest verifier detail for use when verification occurs, ensuring that the
+        // proper fees from when onboarding occurred are used
+        self.use_deps(|deps| {
+            insert_latest_verifier_detail(
+                deps.storage,
+                &attribute.scope_address,
+                latest_verifier_detail,
+            )
+        })?;
         Ok(())
     }
 
@@ -151,8 +168,9 @@ impl<'a> AssetMetaRepository for AssetMetaService<'a> {
             }
             .to_string()
         });
-        if let Some(verifier_detail) = attribute.latest_verifier_detail {
-            attribute.latest_verifier_detail = None;
+        if let Some(verifier_detail) =
+            self.use_deps(|deps| attribute.get_latest_verifier_detail(deps.storage))
+        {
             attribute.latest_verification_result =
                 Some(AssetVerificationResult { message, success });
 
@@ -212,6 +230,10 @@ impl<'a> AssetMetaRepository for AssetMetaService<'a> {
 
             // distribute fees now that verification has happened
             self.append_messages(&calculate_verifier_cost_messages(&verifier_detail)?);
+
+            // Remove the latest verifier detail from storage - it's only needed for discovering
+            // fees, so its existence is no longer relevant after verification completes.
+            self.use_deps(|deps| delete_latest_verifier_detail(deps.storage, &scope_address_str))?;
         } else {
             return ContractError::UnexpectedState {
                 explanation: format!(
@@ -265,7 +287,9 @@ mod tests {
     };
     use serde_json_wasm::to_string;
 
+    use crate::core::state::{delete_latest_verifier_detail, insert_latest_verifier_detail};
     use crate::core::types::verifier_detail::VerifierDetailV2;
+    use crate::testutil::test_utilities::get_default_asset_scope_attribute_and_detail;
     use crate::{
         core::{
             error::ContractError,
@@ -338,11 +362,15 @@ mod tests {
         let repository = AssetMetaService::new(deps.as_mut());
 
         let err = repository
-            .onboard_asset(&get_default_test_attribute(), false)
+            .onboard_asset(
+                &get_default_test_attribute(),
+                &get_default_verifier_detail(),
+                false,
+            )
             .unwrap_err();
 
         match err {
-            crate::core::error::ContractError::AssetAlreadyOnboarded { scope_address } => {
+            ContractError::AssetAlreadyOnboarded { scope_address } => {
                 assert_eq!(
                     DEFAULT_SCOPE_ADDRESS.to_string(),
                     scope_address,
@@ -364,7 +392,11 @@ mod tests {
         let repository = AssetMetaService::new(deps.as_mut());
 
         repository
-            .onboard_asset(&get_default_test_attribute(), false)
+            .onboard_asset(
+                &get_default_test_attribute(),
+                &get_default_verifier_detail(),
+                false,
+            )
             .unwrap();
 
         let messages = repository.get_messages();
@@ -446,7 +478,7 @@ mod tests {
         let attribute = repository.get_asset(DEFAULT_SCOPE_ADDRESS).unwrap();
 
         assert_eq!(
-            get_default_asset_scope_attribute(),
+            get_default_asset_scope_attribute_and_detail(true),
             attribute,
             "Attribute returned from get_asset should match what is expected"
         );
@@ -479,7 +511,7 @@ mod tests {
             .expect("encapsulated asset should be present in the Option");
 
         assert_eq!(
-            get_default_asset_scope_attribute(),
+            get_default_asset_scope_attribute_and_detail(true),
             result,
             "try_get_asset should return attribute for an onboarded asset"
         );
@@ -560,14 +592,7 @@ mod tests {
                     requestor_address: Addr::unchecked(DEFAULT_SENDER_ADDRESS),
                     verifier_address: Addr::unchecked(DEFAULT_VERIFIER_ADDRESS),
                     onboarding_status: AssetOnboardingStatus::Pending,
-                    latest_verifier_detail: VerifierDetailV2 {
-                        address: DEFAULT_VERIFIER_ADDRESS.to_string(),
-                        onboarding_cost: Uint128::new(DEFAULT_ONBOARDING_COST),
-                        onboarding_denom: DEFAULT_ONBOARDING_DENOM.to_string(),
-                        fee_destinations: vec![],
-                        entity_detail: get_default_entity_detail().to_some(),
-                    }
-                    .to_some(),
+                    latest_verifier_detail: None,
                     latest_verification_result: None,
                     access_definitions: vec![
                         AccessDefinition {
@@ -587,6 +612,19 @@ mod tests {
                 "json",
             )],
         );
+
+        insert_latest_verifier_detail(
+            deps.as_mut().storage,
+            DEFAULT_SCOPE_ADDRESS,
+            &VerifierDetailV2 {
+                address: DEFAULT_VERIFIER_ADDRESS.to_string(),
+                onboarding_cost: Uint128::new(DEFAULT_ONBOARDING_COST),
+                onboarding_denom: DEFAULT_ONBOARDING_DENOM.to_string(),
+                fee_destinations: vec![],
+                entity_detail: get_default_entity_detail().to_some(),
+            },
+        )
+        .expect("expected the latest verifier detail to be properly stored");
 
         setup_test_suite(&mut deps, InstArgs::default());
         let repository = AssetMetaService::new(deps.as_mut());
@@ -1005,7 +1043,8 @@ mod tests {
                 ..
             }) => {
                 let mut value = get_default_asset_scope_attribute();
-                value.latest_verifier_detail = None;
+                delete_latest_verifier_detail(deps.as_mut().storage, DEFAULT_SCOPE_ADDRESS)
+                    .expect("latest verifier detail deletion should succeed");
                 value.latest_verification_result = AssetVerificationResult {
                     message: message
                         .unwrap_or_else(|| match result {
@@ -1072,7 +1111,7 @@ mod tests {
             DEFAULT_SENDER_ADDRESS,
             DEFAULT_VERIFIER_ADDRESS,
             AssetOnboardingStatus::Pending.to_some(),
-            get_default_verifier_detail(),
+            &get_default_verifier_detail(),
             get_default_access_routes(),
         )
         .expect("failed to instantiate default asset scope attribute")

--- a/src/testutil/test_utilities.rs
+++ b/src/testutil/test_utilities.rs
@@ -108,6 +108,16 @@ pub fn get_default_access_routes() -> Vec<AccessRoute> {
 }
 
 pub fn get_default_asset_scope_attribute() -> AssetScopeAttribute {
+    get_default_asset_scope_attribute_and_detail(false)
+}
+
+/// Provides the same values as get_default_asset_scope_attribute, but also allows a verifier
+/// detail to be populated.  In all circumstances in normal runtime, the latest_verifier_detail
+/// will be None, because it's only populated in query results.  However, tests will sometimes need
+/// to check against the default values after an onboard occurs.
+pub fn get_default_asset_scope_attribute_and_detail(
+    populate_verifier_detail: bool,
+) -> AssetScopeAttribute {
     AssetScopeAttribute {
         asset_uuid: DEFAULT_ASSET_UUID.to_string(),
         scope_address: DEFAULT_SCOPE_ADDRESS.to_string(),
@@ -115,7 +125,11 @@ pub fn get_default_asset_scope_attribute() -> AssetScopeAttribute {
         requestor_address: Addr::unchecked(DEFAULT_SENDER_ADDRESS.to_string()),
         verifier_address: Addr::unchecked(DEFAULT_VERIFIER_ADDRESS.to_string()),
         onboarding_status: AssetOnboardingStatus::Pending,
-        latest_verifier_detail: Some(get_default_verifier_detail()),
+        latest_verifier_detail: if populate_verifier_detail {
+            get_default_verifier_detail().to_some()
+        } else {
+            None
+        },
         latest_verification_result: None,
         access_definitions: vec![AccessDefinition {
             owner_address: DEFAULT_SENDER_ADDRESS.to_string(),

--- a/src/util/provenance_util.rs
+++ b/src/util/provenance_util.rs
@@ -36,7 +36,7 @@ pub fn get_add_attribute_to_scope_msg(
     if attribute.latest_verifier_detail.is_some() {
         // Ensures that the large latest_verifier_detail field is never populated when an
         // attribute is stored on the Provenance Blockchain.  The Attribute Metadata Module will
-        // reject large payments (currently > 1kb as of the time of writing), so this verifier
+        // reject large payloads (currently > 1kb as of the time of writing), so this verifier
         // detail value should be trimmed from all storage.
         let mut filtered_attribute = attribute.clone();
         filtered_attribute.latest_verifier_detail = None;

--- a/src/util/provenance_util.rs
+++ b/src/util/provenance_util.rs
@@ -17,14 +17,42 @@ pub fn get_add_attribute_to_scope_msg(
     attribute: &AssetScopeAttribute,
     base_contract_name: impl Into<String>,
 ) -> AssetResult<CosmosMsg<ProvenanceMsg>> {
-    add_json_attribute(
-        // Until there's a way to parse a scope address as an Addr, we must use Addr::unchecked.
-        // It's not the best policy, but contract execution will fail if it's an incorrect address,
-        // so it'll just fail later down the line with a less sane error message than if it was
-        // being properly checked.
-        Addr::unchecked(&attribute.scope_address),
-        generate_asset_attribute_name(&attribute.asset_type, base_contract_name),
-        attribute,
-    )
-    .map_err(ContractError::Std)
+    let get_msg = |attribute: &AssetScopeAttribute| {
+        add_json_attribute(
+            // Until there's a way to parse a scope address as an Addr, we must use Addr::unchecked.
+            // It's not the best policy, but contract execution will fail if it's an incorrect address,
+            // so it'll just fail later down the line with a less sane error message than if it was
+            // being properly checked.
+            Addr::unchecked(&attribute.scope_address),
+            generate_asset_attribute_name(&attribute.asset_type, base_contract_name),
+            attribute,
+        )
+        .map_err(ContractError::Std)
+    };
+    // Only clone and update the attribute if the latest_verifier_detail is populated.  This
+    // ensures faster operations when storing an attribute without a latest_verifier_detail.
+    if attribute.latest_verifier_detail.is_some() {
+        // Ensures that the large latest_verifier_detail field is never populated when an
+        // attribute is stored on the Provenance Blockchain.  The Attribute Metadata Module will
+        // reject large payments (currently > 1kb as of the time of writing), so this verifier
+        // detail value should be trimmed from all storage.
+        let mut filtered_attribute = attribute.clone();
+        filtered_attribute.latest_verifier_detail = None;
+        get_msg(&filtered_attribute)
+    } else {
+        get_msg(attribute)
+    }
+}
+
+/// Helper function to ensure that an [AssetScopeAttribute](crate::core::types::asset_scope_attribute::AssetScopeAttribute)
+/// has all of its large fields removed for storage on the Provenance Blockchain.  This is to ensure
+/// that it does not get rejected from the Attribute metadata module for being too large.
+///
+/// # Parameters
+///
+/// * `attribute` An attribute that may or may not have
+pub fn trim_attribute_for_storage(attribute: &AssetScopeAttribute) -> AssetScopeAttribute {
+    let mut filtered_attribute = attribute.clone();
+    filtered_attribute.latest_verifier_detail = None;
+    filtered_attribute
 }

--- a/src/util/provenance_util.rs
+++ b/src/util/provenance_util.rs
@@ -17,6 +17,8 @@ pub fn get_add_attribute_to_scope_msg(
     attribute: &AssetScopeAttribute,
     base_contract_name: impl Into<String>,
 ) -> AssetResult<CosmosMsg<ProvenanceMsg>> {
+    // Pre-declare the primary functionality as a closure, allowing faster operations to be performed
+    // when the scope attribute's latest_verifier_detail is not populated.
     let get_msg = |attribute: &AssetScopeAttribute| {
         add_json_attribute(
             // Until there's a way to parse a scope address as an Addr, we must use Addr::unchecked.
@@ -42,17 +44,4 @@ pub fn get_add_attribute_to_scope_msg(
     } else {
         get_msg(attribute)
     }
-}
-
-/// Helper function to ensure that an [AssetScopeAttribute](crate::core::types::asset_scope_attribute::AssetScopeAttribute)
-/// has all of its large fields removed for storage on the Provenance Blockchain.  This is to ensure
-/// that it does not get rejected from the Attribute metadata module for being too large.
-///
-/// # Parameters
-///
-/// * `attribute` An attribute that may or may not have
-pub fn trim_attribute_for_storage(attribute: &AssetScopeAttribute) -> AssetScopeAttribute {
-    let mut filtered_attribute = attribute.clone();
-    filtered_attribute.latest_verifier_detail = None;
-    filtered_attribute
 }


### PR DESCRIPTION
# Description
Recent changes in the structure of the `VerifierDetailV2` have allowed it to grow to an unacceptable size.  The attribute module of the Provenance Blockchain will reject incoming attribute writes when their size is greater than 1k.  To remedy this, this PR creates internal storage for the latest verifier detail on the scope attribute, and will no longer ever write the attribute with the latest verifier detail on it to the blockchain.  This change will appear cosmetic to an external user, but can have backwards compatibility issues.  As such, the mainnet version of the contract should not be enabled until this new version is added to avoid attribute size rejections.

# Changes
* Bumps the contract version from `v1.0.5` to `v1.0.6`
* Adds a new `Bucket` storage for the `latest_verifier_detail` property that was stored on the attribute before.
* Adds a new `get_latest_verifier_detail` function to the `AssetScopeAttribute` struct that should ALWAYS be used to get the value from storage instead of the struct itself.
* Modify the `onboard_asset` function of the `AssetMetaService` to add the `latest_verifier_detail` to contract storage.
* Modify the `verify_asset` function of the `AssetMetaService` to delete the `latest_verifier_detail` from contract storage after it has been used.
* Modify the `get_add_attribute_to_scope_msg` function to always remove the `latest_verifier_detail` field from an incoming `AssetScopeAttribute` to ensure that it is never included in Provenance Blockchain msg writes